### PR TITLE
Fix/multiple same filter search

### DIFF
--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -37,9 +37,10 @@ class Api::V1::CardsController < ApplicationController
   end
 
   def valid_search_params?
-    keys = format_search_params.flat_map(&:keys)
-    keys.all? { |key|
-    permitted_search_criteria.include?(key) }
+    format_search_params.all? do |param|
+      key, _ = param.first
+      permitted_search_criteria.include?(key)
+    end
   end
 
   def permitted_search_criteria

--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -26,21 +26,20 @@ class Api::V1::CardsController < ApplicationController
   private
   def format_search_params
     query_params = params[:query].split(" ")
-    hash = { }
-    query_params = query_params.each do |string|
+    query_params.map do |string|
       if string.include?(":")
         filter_array = string.split(":")
-        hash[filter_array[0].to_sym] = filter_array[1]
+        { filter_array[0].to_sym => filter_array[1] }
       else
-        hash[:name] = string
+        { name: string }
       end
     end
-    hash
   end
 
   def valid_search_params?
-    keys = format_search_params.keys
-    keys.all? { |key| permitted_search_criteria.include?(key) }
+    keys = format_search_params.flat_map(&:keys)
+    keys.all? { |key|
+    permitted_search_criteria.include?(key) }
   end
 
   def permitted_search_criteria

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,6 +1,15 @@
 class Card < ApplicationRecord
   def self.search(filters)
-    Card.where('name ILIKE ? AND description ILIKE ?', "%#{filters[:name]}%", "%#{filters[:description]}%")
+    cards = Card.all
+
+    filters.each do |filter|
+      key, value = filter.first
+      cards = cards.where("#{key} ILIKE ?", "%#{value}%")
+    end
+
+    cards
+
+    # Card.where('name ILIKE ? AND description ILIKE ?', "%#{filters[:name]}%", "%#{filters[:description]}%")
     # cards = Array.new
 
     # Card.where('name ILIKE ?', "%#{filters[:name]}%").where('description ILIKE ?', "%#{filters[:description]}%")
@@ -18,6 +27,7 @@ class Card < ApplicationRecord
     # final_cards = []
     # filters.each do |filter|
     #   key, value = filter.first
+    #   require 'pry'; binding.pry
     #   final_cards = case key
     #   when :description
     #     cards = cards.where('description ILIKE ?', "%#{value}%")

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe Card, type: :model do
     end
 
     it 'returns all cards with fuzzy name matches when a basic search is used' do
-      search_hash = {name: "drav"}
+      search_array = [{ name: "drav" }]
 
-      cards = Card.search(search_hash)
+      cards = Card.search(search_array)
 
       expect(cards).to be_an(ActiveRecord::Relation)
       expect(cards.count).to eq(8)
@@ -22,9 +22,9 @@ RSpec.describe Card, type: :model do
     end
 
     it "returns all cards with fuzzy description matches when the 'description:text' syntax is used" do
-      search_hash = {description: "axe"}
+      search_array = [{ description: "axe" }]
 
-      cards = Card.search(search_hash)
+      cards = Card.search(search_array)
 
       expect(cards).to be_an(ActiveRecord::Relation)
       expect(cards.count).to eq(5)
@@ -33,14 +33,26 @@ RSpec.describe Card, type: :model do
     end
 
     it "returns all cards that satisfy ALL search parameters when multiple search syntaxes are used" do
-      search_hash = {name: "drav", description: "axe"}
+      search_array = [{ name: "drav" }, { description: "axe" }]
 
-      cards = Card.search(search_hash)
+      cards = Card.search(search_array)
 
       expect(cards).to be_an(ActiveRecord::Relation)
       expect(cards.count).to eq(4)
       expect(cards).to include(@card2)
       expect(cards).to_not include(@card1)
+    end
+
+    it "returns all cards that satisfy ALL search parameters when multiple of the same search stynax is used and not just the last of that syntax" do
+      temp_card = create(:card, name: "Darius's Whirling Death", description: "whirling axe")
+      search_array = [{ name: "dar" }, { name: "whirl" }]
+
+      cards = Card.search(search_array)
+
+      expect(cards).to be_an(ActiveRecord::Relation)
+      expect(cards.count).to eq(1)
+      expect(cards).to include(temp_card)
+      expect(cards).to_not include(@card2)
     end
   end
 end


### PR DESCRIPTION
# Description

Fixed the search only allowing a single instance of a specific attribute filter. Previously, having two searches of "name:value" would only search by the last instance of "name:value".

## Context

We were formatting the search query into a hash of unique keys that fit our attributes. When there were multiple of the same attribute, the last one would overwrite the value since you can only have one unique key. Each hash key value pair is now separated as elements in an array. 

Fixes #19 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Created a new RSpec model test that confirms all instances of a specific attribute filter correctly filter out results.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes