### PR TITLE
Feat/random card

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # Runefall
 
+## Table of Contents
+- [About](#about)
+- [Development Setup](#development-setup)
+- [External APIs and Services](#external-apis-and-services)
+- [End Points](#end-points)
+- [Contributors](#contributors)
+
 ## About
 The Runefall backend service provides an advanced search to filter and query a list of cards available in the videogame Legends of Runeterra. 
 
 You can find a live version of this service being utilized [here.](https://runefall.netlify.app/)
 
-## Development setup
+## Development Setup
 
 This guide assumes you have installed [Rails 7.1.3](https://guides.rubyonrails.org/v7.1/getting_started.html) and [PostgreSQL >= 14](https://www.postgresql.org/download/)
 
@@ -659,6 +666,522 @@ Response: `status: 200`
 ```
 </details>
 
+<details>
+<summary> Get Random Cards</summary>
+
+Request:
+
+```http
+GET /api/v1/cards/random
+Content-Type: application/json
+Accept: application/json
+```
+
+Response: `status: 200`
+
+```json
+{
+    "data": {
+        "id": "2158",
+        "type": "card",
+        "attributes": {
+            "name": "The Swindler's Den",
+            "card_code": "07BW035",
+            "description": "Your cards in hand have <link=keyword.Fleeting><sprite name=Fleeting><style=Keyword>Fleeting</style></link>.\r\nWhen you play a card, draw 1.",
+            "description_raw": "Your cards in hand have Fleeting.\r\nWhen you play a card, draw 1.",
+            "levelup_description": "",
+            "levelup_description_raw": "",
+            "flavor_text": "\"I reckon you ought to know your hand and hold it close, or be prepared to lose it all.\" - Twisted Fate",
+            "artist_name": "Envar Studio",
+            "attack": 0,
+            "cost": 6,
+            "health": 0,
+            "spell_speed": "",
+            "rarity": "EPIC",
+            "supertype": "",
+            "card_type": "Landmark",
+            "collectible": true,
+            "set": "Set7b",
+            "associated_card_refs": [],
+            "regions": [
+                "Bilgewater"
+            ],
+            "region_refs": [
+                "Bilgewater"
+            ],
+            "keywords": [
+                "Landmark"
+            ],
+            "keyword_refs": [
+                "LandmarkVisualOnly"
+            ],
+            "formats": [
+                "Eternal",
+                "Standard"
+            ],
+            "format_refs": [
+                "client_Formats_Eternal_name",
+                "client_Formats_Standard_name"
+            ],
+            "assets": [
+                {
+                    "game_absolute_path": "http://dd.b.pvp.net/5_6_0/set7b/en_us/img/cards/07BW035.png",
+                    "full_absolute_path": "http://dd.b.pvp.net/5_6_0/set7b/en_us/img/cards/07BW035-full.png"
+                }
+            ],
+            "associated_cards": []
+        }
+    }
+}
+```
+
+## Parameters
+The `GET random cards` endpoint can also take in the query parameter of `limit` where it returns a number of random cards up to the limit or total number of cards.
+
+### Example Request: 
+```
+GET /api/v1/cards/random?limit=5
+Content-Type: application/json  
+Accept: application/json  
+```
+
+### Response: ` status: 200 `  
+```
+{
+    "data": [
+        {
+            "id": "287",
+            "type": "card",
+            "attributes": {
+                "name": "Tryndamere's Battle Fury",
+                "card_code": "01FR039T1",
+                "description": "Grant an ally +8|+4.\r\nCreate a <link=card.level1><style=AssociatedCard>Tryndamere</style></link> in your deck.",
+                "description_raw": "Grant an ally +8|+4.\r\nCreate a Tryndamere in your deck.",
+                "levelup_description": "",
+                "levelup_description_raw": "",
+                "flavor_text": "“I've been told I have a... temper.” - Tryndamere",
+                "artist_name": "SIXMOREVODKA",
+                "attack": 0,
+                "cost": 8,
+                "health": 0,
+                "spell_speed": "Burst",
+                "rarity": "None",
+                "supertype": "Champion",
+                "card_type": "Spell",
+                "collectible": false,
+                "set": "Set1",
+                "associated_card_refs": [
+                    "01FR039",
+                    "01FR039T2"
+                ],
+                "regions": [
+                    "Freljord"
+                ],
+                "region_refs": [
+                    "Freljord"
+                ],
+                "keywords": [
+                    "Burst"
+                ],
+                "keyword_refs": [
+                    "Burst"
+                ],
+                "formats": [
+                    "Eternal",
+                    "Standard"
+                ],
+                "format_refs": [
+                    "client_Formats_Eternal_name",
+                    "client_Formats_Standard_name"
+                ],
+                "assets": [
+                    {
+                        "game_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01FR039T1.png",
+                        "full_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01FR039T1-full.png"
+                    }
+                ],
+                "associated_cards": [
+                    {
+                        "id": 286,
+                        "name": "Tryndamere",
+                        "card_code": "01FR039",
+                        "description": "",
+                        "description_raw": "",
+                        "levelup_description": "If I would die, I Level Up instead.",
+                        "levelup_description_raw": "If I would die, I Level Up instead.",
+                        "flavor_text": "\"Do not die for your cause. Live for it...\"",
+                        "artist_name": "SIXMOREVODKA",
+                        "attack": 8,
+                        "cost": 8,
+                        "health": 6,
+                        "spell_speed": "",
+                        "rarity": "Champion",
+                        "supertype": "Champion",
+                        "card_type": "Unit",
+                        "collectible": true,
+                        "set": "Set1",
+                        "associated_card_refs": [
+                            "01FR039T2",
+                            "01FR039T1"
+                        ],
+                        "regions": [
+                            "Freljord"
+                        ],
+                        "region_refs": [
+                            "Freljord"
+                        ],
+                        "keywords": [
+                            "Overwhelm"
+                        ],
+                        "keyword_refs": [
+                            "Overwhelm"
+                        ],
+                        "formats": [
+                            "Commons Only",
+                            "Eternal"
+                        ],
+                        "format_refs": [
+                            "client_Formats_CommonsOnly_name",
+                            "client_Formats_Eternal_name"
+                        ],
+                        "assets": [
+                            {
+                                "game_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01FR039.png",
+                                "full_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01FR039-full.png"
+                            }
+                        ],
+                        "created_at": "2024-07-07T17:38:18.760Z",
+                        "updated_at": "2024-07-07T17:38:18.760Z",
+                        "associated_cards": []
+                    },
+                    {
+                        "id": 288,
+                        "name": "Tryndamere",
+                        "card_code": "01FR039T2",
+                        "description": "",
+                        "description_raw": "",
+                        "levelup_description": "",
+                        "levelup_description_raw": "",
+                        "flavor_text": "\"...And make THEM die for it.\"",
+                        "artist_name": "SIXMOREVODKA",
+                        "attack": 9,
+                        "cost": 8,
+                        "health": 9,
+                        "spell_speed": "",
+                        "rarity": "None",
+                        "supertype": "Champion",
+                        "card_type": "Unit",
+                        "collectible": false,
+                        "set": "Set1",
+                        "associated_card_refs": [
+                            "01FR039",
+                            "01FR039T1"
+                        ],
+                        "regions": [
+                            "Freljord"
+                        ],
+                        "region_refs": [
+                            "Freljord"
+                        ],
+                        "keywords": [
+                            "Overwhelm",
+                            "Fearsome",
+                            "Tough"
+                        ],
+                        "keyword_refs": [
+                            "Overwhelm",
+                            "Fearsome",
+                            "Tough"
+                        ],
+                        "formats": [
+                            "Eternal",
+                            "Standard"
+                        ],
+                        "format_refs": [
+                            "client_Formats_Eternal_name",
+                            "client_Formats_Standard_name"
+                        ],
+                        "assets": [
+                            {
+                                "game_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01FR039T2.png",
+                                "full_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01FR039T2-full.png"
+                            }
+                        ],
+                        "created_at": "2024-07-07T17:38:18.763Z",
+                        "updated_at": "2024-07-07T17:38:18.763Z",
+                        "associated_cards": []
+                    }
+                ]
+            }
+        },
+        {
+            "id": "1104",
+            "type": "card",
+            "attributes": {
+                "name": "Frostguard Thrall",
+                "card_code": "04FR001T1",
+                "description": "",
+                "description_raw": "",
+                "levelup_description": "",
+                "levelup_description_raw": "",
+                "flavor_text": "Freed from its icy tomb, the corrupted troll knew one thing, and one thing only - it must do as its dark mistress commanded.",
+                "artist_name": "Kudos Productions",
+                "attack": 8,
+                "cost": 8,
+                "health": 8,
+                "spell_speed": "",
+                "rarity": "None",
+                "supertype": "",
+                "card_type": "Unit",
+                "collectible": false,
+                "set": "Set4",
+                "associated_card_refs": [],
+                "regions": [
+                    "Freljord"
+                ],
+                "region_refs": [
+                    "Freljord"
+                ],
+                "keywords": [
+                    "Overwhelm"
+                ],
+                "keyword_refs": [
+                    "Overwhelm"
+                ],
+                "formats": [
+                    "Eternal",
+                    "Standard"
+                ],
+                "format_refs": [
+                    "client_Formats_Eternal_name",
+                    "client_Formats_Standard_name"
+                ],
+                "assets": [
+                    {
+                        "game_absolute_path": "http://dd.b.pvp.net/5_6_0/set4/en_us/img/cards/04FR001T1.png",
+                        "full_absolute_path": "http://dd.b.pvp.net/5_6_0/set4/en_us/img/cards/04FR001T1-full.png"
+                    }
+                ],
+                "associated_cards": []
+            }
+        },
+        {
+            "id": "1163",
+            "type": "card",
+            "attributes": {
+                "name": "Symmetry In Stars",
+                "card_code": "04SI012T1",
+                "description": "Kill an ally to deal 3 to the enemy Nexus.",
+                "description_raw": "Kill an ally to deal 3 to the enemy Nexus.",
+                "levelup_description": "",
+                "levelup_description_raw": "",
+                "flavor_text": "\"Now you'll truly shine!\" - Astral Fox",
+                "artist_name": "Kudos Productions",
+                "attack": 0,
+                "cost": 0,
+                "health": 0,
+                "spell_speed": "",
+                "rarity": "None",
+                "supertype": "",
+                "card_type": "Ability",
+                "collectible": false,
+                "set": "Set4",
+                "associated_card_refs": [],
+                "regions": [
+                    "Shadow Isles"
+                ],
+                "region_refs": [
+                    "ShadowIsles"
+                ],
+                "keywords": [
+                    "Skill"
+                ],
+                "keyword_refs": [
+                    "Skill"
+                ],
+                "formats": [
+                    "Eternal",
+                    "Standard"
+                ],
+                "format_refs": [
+                    "client_Formats_Eternal_name",
+                    "client_Formats_Standard_name"
+                ],
+                "assets": [
+                    {
+                        "game_absolute_path": "http://dd.b.pvp.net/5_6_0/set4/en_us/img/cards/04SI012T1.png",
+                        "full_absolute_path": "http://dd.b.pvp.net/5_6_0/set4/en_us/img/cards/04SI012T1-full.png"
+                    }
+                ],
+                "associated_cards": []
+            }
+        },
+        {
+            "id": "1405",
+            "type": "card",
+            "attributes": {
+                "name": "Wrath of the Freljord",
+                "card_code": "05FR014",
+                "description": "<link=vocab.Play><style=Vocab>Play</style></link>:<link=keyword.Frostbite><sprite name=Frostbite><style=Keyword>Frostbite</style></link> an enemy.\r\nEnemies with 3 or less Power can't block.",
+                "description_raw": "Play:Frostbite an enemy.\r\nEnemies with 3 or less Power can't block.",
+                "levelup_description": "",
+                "levelup_description_raw": "",
+                "flavor_text": "\"I was there, years ago... first came the cold, biting and unrelenting. Then a storm, angry and uncaring. Last came a roar, so sharp it cut me to the bone. I fell to my knees and prayed we hadn't made a grave mistake. To call upon a great spirit is to ask for its vengeance... and its mercy.\" - Hyara Allseer ",
+                "artist_name": "Kudos Productions",
+                "attack": 8,
+                "cost": 8,
+                "health": 8,
+                "spell_speed": "",
+                "rarity": "EPIC",
+                "supertype": "",
+                "card_type": "Unit",
+                "collectible": true,
+                "set": "Set5",
+                "associated_card_refs": [],
+                "regions": [
+                    "Freljord"
+                ],
+                "region_refs": [
+                    "Freljord"
+                ],
+                "keywords": [
+                    "Overwhelm",
+                    "Missing Translation"
+                ],
+                "keyword_refs": [
+                    "Overwhelm",
+                    "AuraVisualFakeKeyword"
+                ],
+                "formats": [
+                    "Eternal",
+                    "Standard"
+                ],
+                "format_refs": [
+                    "client_Formats_Eternal_name",
+                    "client_Formats_Standard_name"
+                ],
+                "assets": [
+                    {
+                        "game_absolute_path": "http://dd.b.pvp.net/5_6_0/set5/en_us/img/cards/05FR014.png",
+                        "full_absolute_path": "http://dd.b.pvp.net/5_6_0/set5/en_us/img/cards/05FR014-full.png"
+                    }
+                ],
+                "associated_cards": []
+            }
+        },
+        {
+            "id": "2308",
+            "type": "card",
+            "attributes": {
+                "name": "Spitfire",
+                "card_code": "08NX003T1",
+                "description": "Deal 2 to an enemy and 2 to the enemy Nexus.",
+                "description_raw": "Deal 2 to an enemy and 2 to the enemy Nexus.",
+                "levelup_description": "",
+                "levelup_description_raw": "",
+                "flavor_text": "Wood, steel, flesh--all of it melts in proximity to the firespitter's caustic rage.",
+                "artist_name": "Polar Engine",
+                "attack": 0,
+                "cost": 0,
+                "health": 0,
+                "spell_speed": "",
+                "rarity": "None",
+                "supertype": "",
+                "card_type": "Ability",
+                "collectible": false,
+                "set": "Set8",
+                "associated_card_refs": [
+                    "08NX003"
+                ],
+                "regions": [
+                    "Noxus"
+                ],
+                "region_refs": [
+                    "Noxus"
+                ],
+                "keywords": [
+                    "Elemental Skill"
+                ],
+                "keyword_refs": [
+                    "ElementalSkill"
+                ],
+                "formats": [
+                    "Eternal",
+                    "Standard"
+                ],
+                "format_refs": [
+                    "client_Formats_Eternal_name",
+                    "client_Formats_Standard_name"
+                ],
+                "assets": [
+                    {
+                        "game_absolute_path": "http://dd.b.pvp.net/5_6_0/set8/en_us/img/cards/08NX003T1.png",
+                        "full_absolute_path": "http://dd.b.pvp.net/5_6_0/set8/en_us/img/cards/08NX003T1-full.png"
+                    }
+                ],
+                "associated_cards": [
+                    {
+                        "id": 2307,
+                        "name": "Enraged Firespitter",
+                        "card_code": "08NX003",
+                        "description": "<link=keyword.Elemental Skill><sprite name=ElementalSkill><style=Keyword>Play</style></link>: Deal 2 to an enemy and 2 to the enemy Nexus.",
+                        "description_raw": "Play: Deal 2 to an enemy and 2 to the enemy Nexus.",
+                        "levelup_description": "",
+                        "levelup_description_raw": "",
+                        "flavor_text": "Noxian expansion has claimed many different peoples, settlements, and cultures. Frequently, wild creatures are also at the mercy of the war machine--but in the case of this dragon, each brutal step forward by Noxus is met with an equally brutal inferno of rage.",
+                        "artist_name": "Envar Studio",
+                        "attack": 5,
+                        "cost": 6,
+                        "health": 3,
+                        "spell_speed": "",
+                        "rarity": "EPIC",
+                        "supertype": "",
+                        "card_type": "Unit",
+                        "collectible": true,
+                        "set": "Set8",
+                        "associated_card_refs": [
+                            "08NX003T1"
+                        ],
+                        "regions": [
+                            "Noxus"
+                        ],
+                        "region_refs": [
+                            "Noxus"
+                        ],
+                        "keywords": [
+                            "Challenger"
+                        ],
+                        "keyword_refs": [
+                            "Challenger"
+                        ],
+                        "formats": [
+                            "Eternal",
+                            "Standard"
+                        ],
+                        "format_refs": [
+                            "client_Formats_Eternal_name",
+                            "client_Formats_Standard_name"
+                        ],
+                        "assets": [
+                            {
+                                "game_absolute_path": "http://dd.b.pvp.net/5_6_0/set8/en_us/img/cards/08NX003.png",
+                                "full_absolute_path": "http://dd.b.pvp.net/5_6_0/set8/en_us/img/cards/08NX003-full.png"
+                            }
+                        ],
+                        "created_at": "2024-07-07T17:38:22.863Z",
+                        "updated_at": "2024-07-07T17:38:22.863Z",
+                        "associated_cards": []
+                    }
+                ]
+            }
+        }
+    ]
+}
+```
+
+
+</details>
+
 ## Contributors
 
 * Billy Wallace | [GitHub](https://github.com/wallacebilly1) | [LinkedIn](https://www.linkedin.com/in/wallacebilly1/)
@@ -666,3 +1189,4 @@ Response: `status: 200`
 * Neil Hendren | [GitHub](https://github.com/NeilTheSeal) | [LinkedIn](https://www.linkedin.com/in/neilhendren/)
 * Charles Kwang | [GitHub](https://github.com/KojinKuro) | [LinkedIn](https://www.linkedin.com/in/charleskwangdevs/)
 * Theotis McCray | [GitHub](https://github.com/Virulencies) | [LinkedIn](https://www.linkedin.com/in/theotis-mccray-849262207/)
+* Laurel Bonal | [GitHub](https://github.com/laurelbonal) | [LinkedIn](https://www.linkedin.com/in/laurel-bonal-software-engineer/)

--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -23,7 +23,19 @@ class Api::V1::CardsController < ApplicationController
     end
   end
 
+  def random
+    limit = if params[:limit].to_i > 0
+              params[:limit].to_i
+            else
+              1
+            end
+
+    cards = Card.random_cards(limit)
+    render json: CardSerializer.new(cards)
+  end
+
   private
+
   def format_search_params
     query_params = params[:query].split(" ")
     query_params.map do |string|
@@ -38,12 +50,12 @@ class Api::V1::CardsController < ApplicationController
 
   def valid_search_params?
     format_search_params.all? do |param|
-      key, _ = param.first
+      key, = param.first
       permitted_search_criteria.include?(key)
     end
   end
 
   def permitted_search_criteria
-    [:name, :description]
+    %i[name description]
   end
 end

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -41,4 +41,15 @@ class Card < ApplicationRecord
 
     # final_cards
   end
+
+  def self.random_cards(limit)
+    random_ids = (1..2368).to_a.sample(limit)
+    cards = where(id: random_ids)
+
+    if limit == 1
+      cards.first
+    else
+      cards
+    end
+  end
 end

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -43,7 +43,8 @@ class Card < ApplicationRecord
   end
 
   def self.random_cards(limit)
-    random_ids = (1..2368).to_a.sample(limit)
+    random_ids = (1..count).to_a.sample(limit)
+
     cards = where(id: random_ids)
 
     if limit == 1

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,9 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :cards, only: %i[index]
-      get 'cards/search', to: 'cards#search'
-      get 'cards/:card_code', to: 'cards#show'
+      get "cards/search", to: "cards#search"
+      get "cards/random", to: "cards#random"
+      get "cards/:card_code", to: "cards#show"
     end
   end
   # Defines the root path route ("/")

--- a/db/data/set9.json
+++ b/db/data/set9.json
@@ -1,0 +1,8463 @@
+[
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09SI015T3"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI015.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI015-full.png"
+      }
+    ],
+    "regions": [
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "ShadowIsles"
+    ],
+    "attack": 0,
+    "cost": 4,
+    "health": 0,
+    "description": "I: Kill a unit with total Power and Health 5 or less.\r\nII: <link=keyword.Drain><style=Keyword>Drain</style></link> the enemy Nexus 2.\r\nIII: Summon an exact copy of an ally. It's <link=keyword.Ephemeral><sprite name=Ephemeral><style=Keyword>Ephemeral</style></link> and 1|1.",
+    "descriptionRaw": "I: Kill a unit with total Power and Health 5 or less.\r\nII: Drain the enemy Nexus 2.\r\nIII: Summon an exact copy of an ally. It's Ephemeral and 1|1.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "He climbed the steps to the stage, poem clutched in hand. He hadn't put up any posters advertising this performance, because he already had the only audience he wanted.",
+    "artistName": "Envar Studio",
+    "name": "The Beautiful Disaster",
+    "cardCode": "09SI015",
+    "keywords": [
+      "Landmark",
+      "Slow"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly",
+      "Slow"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "EPIC",
+    "rarityRef": "Epic",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI015T3.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI015T3-full.png"
+      }
+    ],
+    "regions": [
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "ShadowIsles"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Kill a unit with total Power and Health 5 or less.\r\n",
+    "descriptionRaw": "Kill a unit with total Power and Health 5 or less.\r\n",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Oh, valiant sufferer, kindred of my spirit, beloved of my soul, long I have awaited this night...\" - Grimm",
+    "artistName": "Envar Studio",
+    "name": "Poet's Recital",
+    "cardCode": "09SI015T3",
+    "keywords": [
+      "Skill",
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Slow"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI015T5.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI015T5-full.png"
+      }
+    ],
+    "regions": [
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "ShadowIsles"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Summon an exact copy of an ally. It's <link=keyword.Ephemeral><sprite name=Ephemeral><style=Keyword>Ephemeral</style></link> and 1|1.",
+    "descriptionRaw": "Summon an exact copy of an ally. It's Ephemeral and 1|1.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Zzzzzz...\" - Vex",
+    "artistName": "Envar Studio",
+    "name": "Captivated Audience",
+    "cardCode": "09SI015T5",
+    "keywords": [
+      "Skill",
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Slow"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI015T2.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI015T2-full.png"
+      }
+    ],
+    "regions": [
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "ShadowIsles"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "<link=keyword.Drain><style=Keyword>Drain</style></link> the enemy nexus 2.\r\n",
+    "descriptionRaw": "Drain the enemy nexus 2.\r\n",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"...searching for the courage, the strength to confess: your shadow is my sunlight, your gloom my spirit--my withered heart holds affection for you alone...\" - Grimm",
+    "artistName": "Envar Studio",
+    "name": "Wasted Victuals",
+    "cardCode": "09SI015T2",
+    "keywords": [
+      "Skill",
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Slow"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09SI015T5"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI015T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI015T1-full.png"
+      }
+    ],
+    "regions": [
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "ShadowIsles"
+    ],
+    "attack": 0,
+    "cost": 4,
+    "health": 0,
+    "description": "I: Kill a unit with total Power and Health 5 or less.\r\nII: <link=keyword.Drain><style=Keyword>Drain</style></link> the enemy Nexus 2.\r\nIII: Summon an exact copy of an ally. It's <link=keyword.Ephemeral><sprite name=Ephemeral><style=Keyword>Ephemeral</style></link> and 1|1.",
+    "descriptionRaw": "I: Kill a unit with total Power and Health 5 or less.\r\nII: Drain the enemy Nexus 2.\r\nIII: Summon an exact copy of an ally. It's Ephemeral and 1|1.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "He climbed the steps to the stage, poem clutched in hand. He hadn't put up any posters advertising this performance, because he already had the only audience he wanted.",
+    "artistName": "Envar Studio",
+    "name": "The Beautiful Disaster",
+    "cardCode": "09SI015T1",
+    "keywords": [
+      "Landmark",
+      "Slow"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly",
+      "Slow"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09SI015T2"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI015T4.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI015T4-full.png"
+      }
+    ],
+    "regions": [
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "ShadowIsles"
+    ],
+    "attack": 0,
+    "cost": 4,
+    "health": 0,
+    "description": "I: Kill a unit with total Power and Health 5 or less.\r\nII: <link=keyword.Drain><style=Keyword>Drain</style></link> the enemy Nexus 2.\r\nIII: Summon an exact copy of an ally. It's <link=keyword.Ephemeral><sprite name=Ephemeral><style=Keyword>Ephemeral</style></link> and 1|1.",
+    "descriptionRaw": "I: Kill a unit with total Power and Health 5 or less.\r\nII: Drain the enemy Nexus 2.\r\nIII: Summon an exact copy of an ally. It's Ephemeral and 1|1.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "He climbed the steps to the stage, poem clutched in hand. He hadn't put up any posters advertising this performance, because he already had the only audience he wanted.",
+    "artistName": "Envar Studio",
+    "name": "The Beautiful Disaster",
+    "cardCode": "09SI015T4",
+    "keywords": [
+      "Landmark",
+      "Slow"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly",
+      "Slow"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09SI013T3"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI013.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI013-full.png"
+      }
+    ],
+    "regions": [
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "ShadowIsles"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "I-II: Pick an allied follower. Create an <link=keyword.Ephemeral><sprite name=Ephemeral><style=Keyword>Ephemeral</style></link> copy of it in hand with +1|+1.\r\nIII: Revive the <link=vocab.Strongest><style=Vocab>strongest</style></link> dead allied follower and grant it <link=keyword.Ephemeral><sprite name=Ephemeral><style=Keyword>Ephemeral</style></link>.",
+    "descriptionRaw": "I-II: Pick an allied follower. Create an Ephemeral copy of it in hand with +1|+1.\r\nIII: Revive the strongest dead allied follower and grant it Ephemeral.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "In the Grey Realm, tortured forms amass into a spectral army. Once the gates of the mortal realm are opened, they will not be stopped.",
+    "artistName": "Michal Ivan",
+    "name": "The Iron Conquest",
+    "cardCode": "09SI013",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09SI013T4"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI013T5.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI013T5-full.png"
+      }
+    ],
+    "regions": [
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "ShadowIsles"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Revive the <link=vocab.Strongest><style=Vocab>strongest</style></link> dead allied follower and grant it <link=keyword.Ephemeral><sprite name=Ephemeral><style=Keyword>Ephemeral</style></link>.",
+    "descriptionRaw": "Revive the strongest dead allied follower and grant it Ephemeral.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"I will not rest until vengeance is mine.\" - Bladepierced Revenant",
+    "artistName": "Michal Ivan",
+    "name": "Undying Revenge",
+    "cardCode": "09SI013T5",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09SI013"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI013T3.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI013T3-full.png"
+      }
+    ],
+    "regions": [
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "ShadowIsles"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Pick an allied follower. Create an <link=keyword.Ephemeral><sprite name=Ephemeral><style=Keyword>Ephemeral</style></link> copy of it in hand with +1|+1.\r\n",
+    "descriptionRaw": "Pick an allied follower. Create an Ephemeral copy of it in hand with +1|+1.\r\n",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Soon they will all belong to me!\" - Mordekaiser",
+    "artistName": "Michal Ivan",
+    "name": "Iron Legion",
+    "cardCode": "09SI013T3",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09SI013T5"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI013T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI013T1-full.png"
+      }
+    ],
+    "regions": [
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "ShadowIsles"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "I-II: Pick an allied follower. Create an <link=keyword.Ephemeral><sprite name=Ephemeral><style=Keyword>Ephemeral</style></link> copy of it in hand with +1|+1.\r\nIII: Revive the <link=vocab.Strongest><style=Vocab>strongest</style></link> dead allied follower and grant it <link=keyword.Ephemeral><sprite name=Ephemeral><style=Keyword>Ephemeral</style></link>.",
+    "descriptionRaw": "I-II: Pick an allied follower. Create an Ephemeral copy of it in hand with +1|+1.\r\nIII: Revive the strongest dead allied follower and grant it Ephemeral.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "In the Grey Realm, tortured forms amass into a spectral army. Once the gates of the mortal realm are opened, they will not be stopped.",
+    "artistName": "Michal Ivan",
+    "name": "The Iron Conquest",
+    "cardCode": "09SI013T1",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09SI013T3"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI013T4.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI013T4-full.png"
+      }
+    ],
+    "regions": [
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "ShadowIsles"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "I-II: Pick an allied follower. Create an <link=keyword.Ephemeral><sprite name=Ephemeral><style=Keyword>Ephemeral</style></link> copy of it in hand with +1|+1.\r\nIII: Revive the <link=vocab.Strongest><style=Vocab>strongest</style></link> dead allied follower and grant it <link=keyword.Ephemeral><sprite name=Ephemeral><style=Keyword>Ephemeral</style></link>.",
+    "descriptionRaw": "I-II: Pick an allied follower. Create an Ephemeral copy of it in hand with +1|+1.\r\nIII: Revive the strongest dead allied follower and grant it Ephemeral.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "In the Grey Realm, tortured forms amass into a spectral army. Once the gates of the mortal realm are opened, they will not be stopped.",
+    "artistName": "Michal Ivan",
+    "name": "The Iron Conquest",
+    "cardCode": "09SI013T4",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI012.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI012-full.png"
+      }
+    ],
+    "regions": [
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "ShadowIsles"
+    ],
+    "attack": 0,
+    "cost": 4,
+    "health": 0,
+    "description": "Grant enemies <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link>.",
+    "descriptionRaw": "Grant enemies Gloom.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"What's the point of anything, ever?\" - Vex",
+    "artistName": "Caravan Studio",
+    "name": "Existential Dread",
+    "cardCode": "09SI012",
+    "keywords": [
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Slow"
+    ],
+    "spellSpeed": "Slow",
+    "spellSpeedRef": "Slow",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Spell",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "06BW006T3"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI017.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI017-full.png"
+      }
+    ],
+    "regions": [
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "ShadowIsles"
+    ],
+    "attack": 5,
+    "cost": 6,
+    "health": 4,
+    "description": "Whenever a non-<link=card.spawn><style=AssociatedCard>Tentacle</style></link> ally dies, or <link=keyword.Last Breath><sprite name=LastBreath><style=Keyword>Last Breath</style></link>: <link=vocab.Spawn><style=Vocab>Spawn</style></link> 2.",
+    "descriptionRaw": "Whenever a non-Tentacle ally dies, or Last Breath: Spawn 2.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "The lone oarsman of a spectral ship that many seafaring folk call the Last Ferry, Kharox is said to commune with the spirits of all the sailors who perished trying to reach the Isles.",
+    "artistName": "Envar Studio",
+    "name": "Kharox",
+    "cardCode": "09SI017",
+    "keywords": [
+      "Last Breath"
+    ],
+    "keywordRefs": [
+      "LastBreath"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "EPIC",
+    "rarityRef": "Epic",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09SI014T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI014.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI014-full.png"
+      }
+    ],
+    "regions": [
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "ShadowIsles"
+    ],
+    "attack": 5,
+    "cost": 6,
+    "health": 3,
+    "description": "<link=keyword.PlaySkillMark><sprite name=SkillMark><style=Keyword>Play</style></link>: Grant a unit 4 <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link>.",
+    "descriptionRaw": "Play: Grant a unit 4 Gloom.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Dark romantic, tortured poet, and connoisseur of all things philosophical, Grimm isn't afraid of a little gloom and doom. The subject of his affections is known to be a touch prickly, but that only makes her all the more loveable in his eyes.",
+    "artistName": "Envar Studio",
+    "name": "Grimm",
+    "cardCode": "09SI014",
+    "keywords": [
+      "Fearsome"
+    ],
+    "keywordRefs": [
+      "Fearsome"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [
+      "YORDLE"
+    ],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09SI014"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI014T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SI014T1-full.png"
+      }
+    ],
+    "regions": [
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "ShadowIsles"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Grant a unit 4 <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link>.",
+    "descriptionRaw": "Grant a unit 4 Gloom.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"A rose is... only beautiful in its impermanence...\" - Grimm",
+    "artistName": "Wild Blue",
+    "name": "Withering Affection",
+    "cardCode": "09SI014T1",
+    "keywords": [
+      "Skill"
+    ],
+    "keywordRefs": [
+      "Skill"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE033.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE033-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia",
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Demacia",
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 1,
+    "health": 0,
+    "description": "",
+    "descriptionRaw": "",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Spritelings are marvelous creatures. Given enough time, and the right dreamer, their potential is simply limitless!\" - Sprite Mother",
+    "artistName": "Envar Studio",
+    "name": "Spritelings",
+    "cardCode": "09DE033",
+    "keywords": [
+      "Spirit",
+      "Spirit"
+    ],
+    "keywordRefs": [
+      "Spirit",
+      "Spirit"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09DE039T5"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE039.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE039-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "I: Grant an ally <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>.\r\nII: Grant an ally 2 <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>.\r\nIII: <link=vocab.Boost><style=Vocab>Boost</style></link> all allies.",
+    "descriptionRaw": "I: Grant an ally Spirit.\r\nII: Grant an ally 2 Spirit.\r\nIII: Boost all allies.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "The cheers of the crowd swelled as her radiance washed over their upturned faces. She had only ever sought to uplift and support her people--and they supported her in turn, voices rising in a chant of adoration: \"Luxanna! Luxanna! Luxanna!\"",
+    "artistName": "Envar Studio",
+    "name": "The Light of Demacia",
+    "cardCode": "09DE039",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09DE039T3"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE039T2.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE039T2-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "I: Grant an ally <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>.\r\nII: Grant an ally 2 <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>.\r\nIII: <link=vocab.Boost><style=Vocab>Boost</style></link> all allies.",
+    "descriptionRaw": "I: Grant an ally Spirit.\r\nII: Grant an ally 2 Spirit.\r\nIII: Boost all allies.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "The cheers of the crowd swelled as her radiance washed over their upturned faces. She had only ever sought to uplift and support her people--and they supported her in turn, voices rising in a chant of adoration: \"Luxanna! Luxanna! Luxanna!\"",
+    "artistName": "Envar Studio",
+    "name": "The Light of Demacia",
+    "cardCode": "09DE039T2",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09DE039T6"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE039T4.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE039T4-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "I: Grant an ally <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>.\r\nII: Grant an ally 2 <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>.\r\nIII: <link=vocab.Boost><style=Vocab>Boost</style></link> all allies.",
+    "descriptionRaw": "I: Grant an ally Spirit.\r\nII: Grant an ally 2 Spirit.\r\nIII: Boost all allies.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "The cheers of the crowd swelled as her radiance washed over their upturned faces. She had only ever sought to uplift and support her people--and they supported her in turn, voices rising in a chant of adoration: \"Luxanna! Luxanna! Luxanna!\"",
+    "artistName": "Envar Studio",
+    "name": "The Light of Demacia",
+    "cardCode": "09DE039T4",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE039T5.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE039T5-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Grant an ally <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>.",
+    "descriptionRaw": "Grant an ally Spirit.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"I will protect you!\" - Lux: Illuminated",
+    "artistName": "Envar Studio",
+    "name": "Radiant Protection",
+    "cardCode": "09DE039T5",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE039T6.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE039T6-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Grant an ally 2 <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>.",
+    "descriptionRaw": "Grant an ally 2 Spirit.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Look around you! This is the might of Demacia!\" - Lux: Illuminated",
+    "artistName": "Envar Studio",
+    "name": "Stone Sentry",
+    "cardCode": "09DE039T6",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09DE039T2"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE039T3.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE039T3-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "<link=vocab.Boost><style=Vocab>Boost</style></link> all allies.",
+    "descriptionRaw": "Boost all allies.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Together, with hearts incandescent!\" - Lux: Illuminated",
+    "artistName": "Envar Studio",
+    "name": "Hearts Incandescent",
+    "cardCode": "09DE039T3",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09DE034T1",
+      "09DE034T2"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE034.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE034-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 1,
+    "cost": 3,
+    "health": 2,
+    "description": "<link=keyword.Support><style=Keyword>Support</style></link>: Grant my supported ally <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link> and give me <link=keyword.Barrier><sprite name=Barrier><style=Keyword>Barrier</style></link> this round.",
+    "descriptionRaw": "Support: Grant my supported ally Spirit and give me Barrier this round.",
+    "levelupDescription": "Allies have attacked with or have gained while attacking 20+ total positive keywords. <style=Variable></style>",
+    "levelupDescriptionRaw": "Allies have attacked with or have gained while attacking 20+ total positive keywords. ",
+    "flavorText": "Light swirled and arced around Luxanna as the city folk looked on in wonder. Here, she was Demacia's Lady of Light, an upstanding young Crownguard and a talented mage. Here, Demacia was everything she had always wanted it to be.",
+    "artistName": "Envar Studio",
+    "name": "Lux: Illuminated",
+    "cardCode": "09DE034",
+    "keywords": [
+      "Spirit",
+      "Support"
+    ],
+    "keywordRefs": [
+      "Spirit",
+      "Support"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "Champion",
+    "rarityRef": "Champion",
+    "subtypes": [],
+    "supertype": "Champion",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "04SH003T14"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE047.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE047-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 0,
+    "cost": 6,
+    "health": 0,
+    "description": "Summon a <link=card.summon><style=AssociatedCard>Sandstone Charger</style></link>, then give your allies <link=keyword.Challenger><sprite name=Challenger><style=Keyword>Challenger</style></link> this round.",
+    "descriptionRaw": "Summon a Sandstone Charger, then give your allies Challenger this round.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Deep in a Mageseeker vault of confiscated magical objects, a strange carving sits unlabeled, its purpose long forgotten...",
+    "artistName": "Wild Blue",
+    "name": "Forgotten Artifact",
+    "cardCode": "09DE047",
+    "keywords": [
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Focus"
+    ],
+    "spellSpeed": "Burst",
+    "spellSpeedRef": "Burst",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Spell",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09DE041T1",
+      "08DE017T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE041.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE041-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 0,
+    "cost": 4,
+    "health": 0,
+    "description": "I: An ally <link=keyword.Capture><sprite name=Capture><style=Keyword>Captures</style></link> a unit.\r\nII: <link=keyword.Curse><sprite name=Curse><style=Keyword>Curse</style></link> your opponent with <link=card.curse><style=AssociatedCard>Suppression</style></link>.\r\nIII: <link=vocab.Obliterate><style=Vocab>Obliterate</style></link> all cards <link=keyword.Capture><sprite name=Capture><style=Keyword>Captured</style></link> by allies.",
+    "descriptionRaw": "I: An ally Captures a unit.\r\nII: Curse your opponent with Suppression.\r\nIII: Obliterate all cards Captured by allies.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "The cheers of the crowd faded as she entered the hall. The statues looked on in silence. Darkness awaited, but she could not turn back--who else could prevent Demacia's descent into nightmare?",
+    "artistName": "Envar Studio",
+    "name": "The Petricite Hall",
+    "cardCode": "09DE041",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "EPIC",
+    "rarityRef": "Epic",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09DE034",
+      "09DE034T2"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE034T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE034T1-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 2,
+    "cost": 3,
+    "health": 3,
+    "description": "<link=keyword.Support><style=Keyword>Support</style></link>: Grant my supported ally <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link> and give me <link=keyword.Barrier><sprite name=Barrier><style=Keyword>Barrier</style></link> this round.\r\nWhen an ally gains <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>, it gains it again.",
+    "descriptionRaw": "Support: Grant my supported ally Spirit and give me Barrier this round.\r\nWhen an ally gains Spirit, it gains it again.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"I am Luxanna, Lady of Light, and I am not afraid! You may try to twist my Demacia into nightmare and drown it in darkness, but there is no shadow I cannot outshine!\"",
+    "artistName": "Envar Studio",
+    "name": "Lux: Illuminated",
+    "cardCode": "09DE034T1",
+    "keywords": [
+      "Spirit",
+      "Support"
+    ],
+    "keywordRefs": [
+      "Spirit",
+      "Support"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "Champion",
+    "rarityRef": "Champion",
+    "subtypes": [],
+    "supertype": "Champion",
+    "type": "Unit",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09DE034",
+      "09DE034T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE034T2.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE034T2-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "<link=vocab.Boost><style=Vocab>Boost</style></link> all units. \r\nCreate a <link=card.level1><style=AssociatedCard>Lux: Illuminated</style></link> in your deck.",
+    "descriptionRaw": "Boost all units. \r\nCreate a Lux: Illuminated in your deck.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Our radiance is unbound!\" - Lux: Illuminated",
+    "artistName": "Wild Blue",
+    "name": "Lux's Incandescence",
+    "cardCode": "09DE034T2",
+    "keywords": [
+      "Fast"
+    ],
+    "keywordRefs": [
+      "Fast"
+    ],
+    "spellSpeed": "Fast",
+    "spellSpeedRef": "Fast",
+    "rarity": "Champion",
+    "rarityRef": "Champion",
+    "subtypes": [],
+    "supertype": "Champion",
+    "type": "Spell",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE030.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE030-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "<link=vocab.Boost><style=Vocab>Boost</style></link> all units.",
+    "descriptionRaw": "Boost all units.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Our radiance is unbound!\" - Lux: Illuminated",
+    "artistName": "Wild Blue",
+    "name": "Incandescence",
+    "cardCode": "09DE030",
+    "keywords": [
+      "Fast"
+    ],
+    "keywordRefs": [
+      "Fast"
+    ],
+    "spellSpeed": "Fast",
+    "spellSpeedRef": "Fast",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Spell",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE043.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE043-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 0,
+    "cost": 6,
+    "health": 0,
+    "description": "<link=vocab.Boost><style=Vocab>Boost</style></link> all units 3 times.",
+    "descriptionRaw": "Boost all units 3 times.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Enshrined in light!\" - Lux: Illuminated",
+    "artistName": "Wild Blue",
+    "name": "Rising Light",
+    "cardCode": "09DE043",
+    "keywords": [
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Slow"
+    ],
+    "spellSpeed": "Slow",
+    "spellSpeedRef": "Slow",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Spell",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE031.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE031-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 0,
+    "cost": 1,
+    "health": 0,
+    "description": "<link=vocab.Play><style=Vocab>Play</style></link>: Grant an ally in hand <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>.",
+    "descriptionRaw": "Play: Grant an ally in hand Spirit.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "A young man in a masquerade mask manifested before her with a flourish of rose petals and luminescent creatures. \"The name's Lightfeather. Jarro Lightfeather,\" he said. \"I was told you might be in need of some assistance, my lady?\"",
+    "artistName": "Envar Studio",
+    "name": "Jarro Lightfeather",
+    "cardCode": "09DE031",
+    "keywords": [
+      "Spirit"
+    ],
+    "keywordRefs": [
+      "Spirit"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE046.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE046-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 0,
+    "cost": 5,
+    "health": 0,
+    "description": "<link=vocab.Boost><style=Vocab>Boost</style></link> 2 allies, then they <link=vocab.Strike><style=Vocab>Strike</style></link> an enemy one after another.",
+    "descriptionRaw": "Boost 2 allies, then they Strike an enemy one after another.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Relax, ladies. There's enough of me to go around.\" - Jarro Lightfeather",
+    "artistName": "Wild Blue",
+    "name": "Smoldering Smirk",
+    "cardCode": "09DE046",
+    "keywords": [
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Slow"
+    ],
+    "spellSpeed": "Slow",
+    "spellSpeedRef": "Slow",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Spell",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09DE033"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE045.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE045-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 1,
+    "cost": 8,
+    "health": 1,
+    "description": "When I'm summoned, summon 5 <link=card.sleeper><style=AssociatedCard>Spritelings</style></link>. For each one there isn't space for, grant the <link=keyword.Weakest><style=Keyword>Weakest</style></link> ally 2 <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link> instead.",
+    "descriptionRaw": "When I'm summoned, summon 5 Spritelings. For each one there isn't space for, grant the Weakest ally 2 Spirit instead.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"When I was your age, I was so afraid of this light. I didn't have anyone to tell me that my magic was a gift; that it was given to me for a reason. But you have me to tell you now. So don't be afraid, Alina. Let it shine.\" - Lux: Illuminated",
+    "artistName": "Wild Blue",
+    "name": "Dreamlight Alina",
+    "cardCode": "09DE045",
+    "keywords": [
+      "Spirit"
+    ],
+    "keywordRefs": [
+      "Spirit"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "EPIC",
+    "rarityRef": "Epic",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE041T2.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE041T2-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "<link=vocab.Obliterate><style=Vocab>Obliterate</style></link> all cards <link=keyword.Capture><sprite name=Capture><style=Keyword>Captured</style></link> by allies.",
+    "descriptionRaw": "Obliterate all cards Captured by allies.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Is a little shade like that supposed to frighten me?\" - Lux: Illuminated",
+    "artistName": "Envar Studio",
+    "name": "Umbral Smoke",
+    "cardCode": "09DE041T2",
+    "keywords": [
+      "Skill",
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Slow"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "08DE017T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE041T3.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE041T3-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": " <link=keyword.Curse><sprite name=Curse><style=Keyword>Curse</style></link> your opponent with <link=card.curse><style=AssociatedCard>Suppression</style></link>.",
+    "descriptionRaw": " Curse your opponent with Suppression.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"I don't remember that statue of Aunt Tianna...\" - Lux: Illuminated",
+    "artistName": "Envar Studio",
+    "name": "Petricite Effigy",
+    "cardCode": "09DE041T3",
+    "keywords": [
+      "Skill",
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Slow"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09DE041T2",
+      "08DE017T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE041T4.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE041T4-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "I. An ally <link=keyword.Capture><sprite name=Capture><style=Keyword>captures</style></link> a unit.\r\nII. <link=keyword.Curse><sprite name=Curse><style=Keyword>Curse</style></link> your opponent with <link=card.curse><style=AssociatedCard>Suppression</style></link>.\r\nIII: <link=vocab.Obliterate><style=Vocab>Obliterate</style></link> all cards <link=keyword.Capture><sprite name=Capture><style=Keyword>captured</style></link> by allies.",
+    "descriptionRaw": "I. An ally captures a unit.\r\nII. Curse your opponent with Suppression.\r\nIII: Obliterate all cards captured by allies.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "The cheers of the crowd faded as she entered the hall. The statues looked on in silence. Darkness awaited, but she could not turn back--who else could prevent Demacia's descent into nightmare?",
+    "artistName": "Envar Studio",
+    "name": "The Petricite Hall",
+    "cardCode": "09DE041T4",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09DE041T3",
+      "08DE017T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE041T5.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE041T5-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "I. An ally <link=keyword.Capture><sprite name=Capture><style=Keyword>captures</style></link> a unit.\r\nII. <link=keyword.Curse><sprite name=Curse><style=Keyword>Curse</style></link> your opponent with <link=card.curse><style=AssociatedCard>Suppression</style></link>.\r\nIII: <link=vocab.Obliterate><style=Vocab>Obliterate</style></link> all cards <link=keyword.Capture><sprite name=Capture><style=Keyword>captured</style></link> by allies.",
+    "descriptionRaw": "I. An ally captures a unit.\r\nII. Curse your opponent with Suppression.\r\nIII: Obliterate all cards captured by allies.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "The cheers of the crowd faded as she entered the hall. The statues looked on in silence. Darkness awaited, but she could not turn back--who else could prevent Demacia's descent into nightmare?",
+    "artistName": "Envar Studio",
+    "name": "The Petricite Hall",
+    "cardCode": "09DE041T5",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE041T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE041T1-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "An ally <link=keyword.Capture><sprite name=Capture><style=Keyword>Captures</style></link> a unit.",
+    "descriptionRaw": "An ally Captures a unit.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Come out and face me, or I will burn away the shadows you cower in!\" - Lux: Illuminated",
+    "artistName": "Envar Studio",
+    "name": "Grasping Hands",
+    "cardCode": "09DE041T1",
+    "keywords": [
+      "Skill",
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Slow"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE040.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE040-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 2,
+    "cost": 5,
+    "health": 3,
+    "description": "When I'm summoned, grant other allies <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>.",
+    "descriptionRaw": "When I'm summoned, grant other allies Spirit.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Lady Crownguard.\" The Mageseeker materialized out of the shadows, extending a hand towards her. His entreating smile seemed too wide for his half-obscured face. \"Why don't you follow me?\"",
+    "artistName": "Envar Studio",
+    "name": "Aberrant Mageseeker",
+    "cardCode": "09DE040",
+    "keywords": [
+      "Challenger"
+    ],
+    "keywordRefs": [
+      "Challenger"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09DE036T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE036.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE036-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia",
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "Demacia",
+      "BandleCity"
+    ],
+    "attack": 2,
+    "cost": 4,
+    "health": 2,
+    "description": "<link=keyword.PlaySkillMark><sprite name=SkillMark><style=Keyword>Play</style></link>: <link=vocab.Boost><style=Vocab>Boost</style></link> all other units.",
+    "descriptionRaw": "Play: Boost all other units.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Go on, little sprites. Show your dreamer the way.\" - Lillia",
+    "artistName": "Envar Studio",
+    "name": "Tree Sprites",
+    "cardCode": "09DE036",
+    "keywords": [
+      "Spirit"
+    ],
+    "keywordRefs": [
+      "Spirit"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE036T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE036T1-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia",
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "Demacia",
+      "BandleCity"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "<link=vocab.Boost><style=Vocab>Boost</style></link> all other units.",
+    "descriptionRaw": "Boost all other units.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Doesn't everybody dream about being the hero?\" - Poppy",
+    "artistName": "Wild Blue",
+    "name": "Bandle Bright",
+    "cardCode": "09DE036T1",
+    "keywords": [
+      "Skill"
+    ],
+    "keywordRefs": [
+      "Skill"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE029.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09DE029-full.png"
+      }
+    ],
+    "regions": [
+      "Demacia"
+    ],
+    "regionRefs": [
+      "Demacia"
+    ],
+    "attack": 2,
+    "cost": 2,
+    "health": 2,
+    "description": "<link=keyword.Support><style=Keyword>Support</style></link>: Give my supported ally all of my positive keywords and their stacks this round.",
+    "descriptionRaw": "Support: Give my supported ally all of my positive keywords and their stacks this round.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Come on, Mister Sprite. Let's burn away these creepy shadows!\" - Dreamlight Alina",
+    "artistName": "Envar Studio",
+    "name": "Luminosprite",
+    "cardCode": "09DE029",
+    "keywords": [
+      "Support"
+    ],
+    "keywordRefs": [
+      "Support"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SH010.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SH010-full.png"
+      }
+    ],
+    "regions": [
+      "Shurima"
+    ],
+    "regionRefs": [
+      "Shurima"
+    ],
+    "attack": 4,
+    "cost": 3,
+    "health": 2,
+    "description": "<link=vocab.Play><style=Vocab>Play</style></link>: Grant an allied landmark, \"When I'm destroyed, revive me.\"",
+    "descriptionRaw": "Play: Grant an allied landmark, \"When I'm destroyed, revive me.\"",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "The rise of the Emperor has inspired hope across Shurima. Determined to see Azir's vision fulfilled, this mage calls herself the 'Empire's Reconstructor' and travels the desert for the purpose of restoring buried ruins to their former splendor.",
+    "artistName": "Pandart",
+    "name": "Empire Reconstructor",
+    "cardCode": "09SH010",
+    "keywords": [],
+    "keywordRefs": [],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09SH009T4",
+      "04SH003T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SH009.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SH009-full.png"
+      }
+    ],
+    "regions": [
+      "Shurima"
+    ],
+    "regionRefs": [
+      "Shurima"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "I: Summon 2 <link=card.summon><style=AssociatedCard>Sand Soldiers</style></link>.\r\nII: <link=vocab.Predict><style=Vocab>Predict</style></link>.\r\nIII: When you summon an ally this round, give it +2|+0 this round.",
+    "descriptionRaw": "I: Summon 2 Sand Soldiers.\r\nII: Predict.\r\nIII: When you summon an ally this round, give it +2|+0 this round.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Azir knows Shurima as it was, is, and will be. He believes that his vision for the future is far more than a mere dream--it is a prophecy he is destined to fulfill.",
+    "artistName": "Envar Studio",
+    "name": "The Emperor's Army",
+    "cardCode": "09SH009",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "EPIC",
+    "rarityRef": "Epic",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SH009T5.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SH009T5-full.png"
+      }
+    ],
+    "regions": [
+      "Shurima"
+    ],
+    "regionRefs": [
+      "Shurima"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "When you summon an ally this round, give it +2|+0 this round.",
+    "descriptionRaw": "When you summon an ally this round, give it +2|+0 this round.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"We serve the ever-lasting glory of Shurima!\" - General of the Dunes",
+    "artistName": "Envar Studio",
+    "name": "Sunsoaked Fervor",
+    "cardCode": "09SH009T5",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "04SH003T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SH009T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SH009T1-full.png"
+      }
+    ],
+    "regions": [
+      "Shurima"
+    ],
+    "regionRefs": [
+      "Shurima"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "<link=vocab.Predict><style=Vocab>Predict</style></link>.",
+    "descriptionRaw": "Predict.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"See what will be.\" - Azir",
+    "artistName": "Envar Studio",
+    "name": "Sand Strategy",
+    "cardCode": "09SH009T1",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09SH009T1",
+      "04SH003T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SH009T3.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SH009T3-full.png"
+      }
+    ],
+    "regions": [
+      "Shurima"
+    ],
+    "regionRefs": [
+      "Shurima"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "I: Summon 2 <link=card.summon><style=AssociatedCard>Sand Soldiers</style></link>.\r\nII: <link=vocab.Predict><style=Vocab>Predict</style></link>.\r\nIII: When you summon an ally this round, give it +2|+0 this round.",
+    "descriptionRaw": "I: Summon 2 Sand Soldiers.\r\nII: Predict.\r\nIII: When you summon an ally this round, give it +2|+0 this round.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Azir knows Shurima as it was, is, and will be. He believes that his vision for the future is far more than a mere dream--it is a prophecy he is destined to fulfill.",
+    "artistName": "Envar Studio",
+    "name": "The Emperor's Army",
+    "cardCode": "09SH009T3",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09SH009T5",
+      "04SH003T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SH009T2.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SH009T2-full.png"
+      }
+    ],
+    "regions": [
+      "Shurima"
+    ],
+    "regionRefs": [
+      "Shurima"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "I: Summon 2 <link=card.summon><style=AssociatedCard>Sand Soldiers</style></link>.\r\nII: <link=vocab.Predict><style=Vocab>Predict</style></link>.\r\nIII: When you summon an ally this round, give it +2|+0 this round.",
+    "descriptionRaw": "I: Summon 2 Sand Soldiers.\r\nII: Predict.\r\nIII: When you summon an ally this round, give it +2|+0 this round.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Azir knows Shurima as it was, is, and will be. He believes that his vision for the future is far more than a mere dream--it is a prophecy he is destined to fulfill.",
+    "artistName": "Envar Studio",
+    "name": "The Emperor's Army",
+    "cardCode": "09SH009T2",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "04SH003T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SH009T4.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SH009T4-full.png"
+      }
+    ],
+    "regions": [
+      "Shurima"
+    ],
+    "regionRefs": [
+      "Shurima"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Summon 2 <link=card.summon><style=AssociatedCard>Sand Soldiers</style></link>.\r\n",
+    "descriptionRaw": "Summon 2 Sand Soldiers.\r\n",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"My soldiers are as numerous as the dunes in the desert.\" - Azir",
+    "artistName": "Envar Studio",
+    "name": "Soldiers' Summons",
+    "cardCode": "09SH009T4",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SH012.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09SH012-full.png"
+      }
+    ],
+    "regions": [
+      "Shurima"
+    ],
+    "regionRefs": [
+      "Shurima"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "Pick 1 of 3 champions that started in your deck and draw it.",
+    "descriptionRaw": "Pick 1 of 3 champions that started in your deck and draw it.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Many artefacts of ancient Sunborn warriors have been lost to time. The same cannot always be said of the god-warriors they represent.",
+    "artistName": "Wild Blue",
+    "name": "Sunborn Summoning",
+    "cardCode": "09SH012",
+    "keywords": [
+      "Burst"
+    ],
+    "keywordRefs": [
+      "Burst"
+    ],
+    "spellSpeed": "Burst",
+    "spellSpeedRef": "Burst",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Spell",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09PZ044T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09PZ044.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09PZ044-full.png"
+      }
+    ],
+    "regions": [
+      "Piltover & Zaun"
+    ],
+    "regionRefs": [
+      "PiltoverZaun"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "I-II: <link=vocab.Updraft><style=Vocab>Updraft</style></link> 1 to draw 1.\r\nIII: Draw 1. ",
+    "descriptionRaw": "I-II: Updraft 1 to draw 1.\r\nIII: Draw 1. ",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "This temple to Janna has few solid walls, so as to be better in tune with its goddess' powers. Nevertheless, the many candles seem always to be lit, even when a howling storm settles over the rest of Zaun.",
+    "artistName": "Envar Studio",
+    "name": "The Candlelit Prayer",
+    "cardCode": "09PZ044",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "EPIC",
+    "rarityRef": "Epic",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09PZ045.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09PZ045-full.png"
+      }
+    ],
+    "regions": [
+      "Piltover & Zaun"
+    ],
+    "regionRefs": [
+      "PiltoverZaun"
+    ],
+    "attack": 3,
+    "cost": 3,
+    "health": 3,
+    "description": "<link=vocab.Play><style=Vocab>Play</style></link>: <link=vocab.Updraft><style=Vocab>Updraft</style></link> 1 to draw another card that costs either more or less than the card you <link=vocab.Updraft><style=Vocab>Updrafted</style></link>. ",
+    "descriptionRaw": "Play: Updraft 1 to draw another card that costs either more or less than the card you Updrafted. ",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Altitude is the surest way to make one recognize their own insignificance.\"",
+    "artistName": "Wild Blue",
+    "name": "Soaring Cartographer",
+    "cardCode": "09PZ045",
+    "keywords": [
+      "Brash"
+    ],
+    "keywordRefs": [
+      "Brash"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09PZ044"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09PZ044T2.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09PZ044T2-full.png"
+      }
+    ],
+    "regions": [
+      "Piltover & Zaun"
+    ],
+    "regionRefs": [
+      "PiltoverZaun"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Draw 1.",
+    "descriptionRaw": "Draw 1.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"This temple is open to all who seek her windborne grace.\" - Maryam, Temple Caretaker",
+    "artistName": "Envar Studio",
+    "name": "Disciple of the Gale",
+    "cardCode": "09PZ044T2",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09PZ044T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09PZ044T3.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09PZ044T3-full.png"
+      }
+    ],
+    "regions": [
+      "Piltover & Zaun"
+    ],
+    "regionRefs": [
+      "PiltoverZaun"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "I-II: <link=vocab.Updraft><style=Vocab>Updraft</style></link> 1 to draw 1.\r\nIII: Draw 1. ",
+    "descriptionRaw": "I-II: Updraft 1 to draw 1.\r\nIII: Draw 1. ",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "This temple to Janna has few solid walls, so as to be better in tune with its goddess' powers. Nevertheless, the many candles seem always to be lit, even when a howling storm settles over the rest of Zaun.",
+    "artistName": "Envar Studio",
+    "name": "The Candlelit Prayer",
+    "cardCode": "09PZ044T3",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09PZ044T2"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09PZ044T4.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09PZ044T4-full.png"
+      }
+    ],
+    "regions": [
+      "Piltover & Zaun"
+    ],
+    "regionRefs": [
+      "PiltoverZaun"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "I-II: <link=vocab.Updraft><style=Vocab>Updraft</style></link> 1 to draw 1.\r\nIII: Draw 1. ",
+    "descriptionRaw": "I-II: Updraft 1 to draw 1.\r\nIII: Draw 1. ",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "This temple to Janna has few solid walls, so as to be better in tune with its goddess' powers. Nevertheless, the many candles seem always to be lit, even when a howling storm settles over the rest of Zaun.",
+    "artistName": "Envar Studio",
+    "name": "The Candlelit Prayer",
+    "cardCode": "09PZ044T4",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09PZ044T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09PZ044T1-full.png"
+      }
+    ],
+    "regions": [
+      "Piltover & Zaun"
+    ],
+    "regionRefs": [
+      "PiltoverZaun"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "<link=vocab.Updraft><style=Vocab>Updraft</style></link> 1 to draw 1.",
+    "descriptionRaw": "Updraft 1 to draw 1.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"A candle cannot burn without her blessed breath to feed it.\" - Maryam, Temple Caretaker",
+    "artistName": "Envar Studio",
+    "name": "Blessed Breath",
+    "cardCode": "09PZ044T1",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09PZ045T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09PZ045T1-full.png"
+      }
+    ],
+    "regions": [
+      "Piltover & Zaun"
+    ],
+    "regionRefs": [
+      "PiltoverZaun"
+    ],
+    "attack": 3,
+    "cost": 3,
+    "health": 3,
+    "description": "<link=vocab.Updraft><style=Vocab>Updraft</style></link> 1 to draw another card that costs more than the card you  <link=vocab.Updraft><style=Vocab>Updrafted</style></link>. ",
+    "descriptionRaw": "Updraft 1 to draw another card that costs more than the card you  Updrafted. ",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Altitude is the surest way to make one recognize their own insignificance.\"",
+    "artistName": "Wild Blue",
+    "name": "Soaring Cartographer",
+    "cardCode": "09PZ045T1",
+    "keywords": [
+      "Brash"
+    ],
+    "keywordRefs": [
+      "Brash"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09PZ045T2.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09PZ045T2-full.png"
+      }
+    ],
+    "regions": [
+      "Piltover & Zaun"
+    ],
+    "regionRefs": [
+      "PiltoverZaun"
+    ],
+    "attack": 3,
+    "cost": 3,
+    "health": 3,
+    "description": "<link=vocab.Updraft><style=Vocab>Updraft</style></link> 1 to draw another card that costs less than the card you <link=vocab.Updraft><style=Vocab>Updrafted</style></link>. ",
+    "descriptionRaw": "Updraft 1 to draw another card that costs less than the card you Updrafted. ",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Altitude is the surest way to make one recognize their own insignificance.\"",
+    "artistName": "Wild Blue",
+    "name": "Soaring Cartographer",
+    "cardCode": "09PZ045T2",
+    "keywords": [
+      "Brash"
+    ],
+    "keywordRefs": [
+      "Brash"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "05BC167T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09PZ046.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09PZ046-full.png"
+      }
+    ],
+    "regions": [
+      "Piltover & Zaun"
+    ],
+    "regionRefs": [
+      "PiltoverZaun"
+    ],
+    "attack": 0,
+    "cost": 8,
+    "health": 0,
+    "description": "Pick an allied follower. Summon 2 <link=card.create><style=AssociatedCard>Hungry Owlcats</style></link> then transform allies into exact copies of the chosen ally.",
+    "descriptionRaw": "Pick an allied follower. Summon 2 Hungry Owlcats then transform allies into exact copies of the chosen ally.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Just one more copy... and then it will be perfect.\" - Evil Imperfectionist",
+    "artistName": "Wild Blue",
+    "name": "Malmutation",
+    "cardCode": "09PZ046",
+    "keywords": [
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Slow"
+    ],
+    "spellSpeed": "Slow",
+    "spellSpeedRef": "Slow",
+    "rarity": "EPIC",
+    "rarityRef": "Epic",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Spell",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09DE033"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO055.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO055-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 1,
+    "cost": 2,
+    "health": 1,
+    "description": "When I'm summoned, summon <link=card.sleeper><style=AssociatedCard>Spritelings</style></link>.",
+    "descriptionRaw": "When I'm summoned, summon Spritelings.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Our Lillia's hair looks a mess! Go and fix it for us, won't you? Remember, the first strand is for wishes, the second for dreams, and the last one for everything that's not as it seems.\" - Sprite Mother",
+    "artistName": "Envar Studio",
+    "name": "Petal Pixie",
+    "cardCode": "09IO055",
+    "keywords": [],
+    "keywordRefs": [],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO056.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO056-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "Recall an ally to grant all stacks of its <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link> to another ally.",
+    "descriptionRaw": "Recall an ally to grant all stacks of its Spirit to another ally.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Dreams of the heart are one drowse from reality!\" - Lillia",
+    "artistName": "Wild Blue",
+    "name": "Sprite Dance",
+    "cardCode": "09IO056",
+    "keywords": [
+      "Fast"
+    ],
+    "keywordRefs": [
+      "Fast"
+    ],
+    "spellSpeed": "Fast",
+    "spellSpeedRef": "Fast",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Spell",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09DE033"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO048.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO048-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 2,
+    "cost": 4,
+    "health": 1,
+    "description": "When I'm summoned, grant allied <link=card.sleeper><style=AssociatedCard>Spritelings</style></link> and <link=card.self><style=AssociatedCard>Sprite Mothers</style></link> <link=vocab.Everywhere><style=Vocab>Everywhere</style></link> <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>.\r\n",
+    "descriptionRaw": "When I'm summoned, grant allied Spritelings and Sprite Mothers Everywhere Spirit.\r\n",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Sprites are spirited, fickle, and not always good listeners. To ensure each one reaches its dreamer, Sprite Mother looks after them with a steady hand and no small amount of scolding.",
+    "artistName": "Envar Studio",
+    "name": "Sprite Mother",
+    "cardCode": "09IO048",
+    "keywords": [],
+    "keywordRefs": [],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "EPIC",
+    "rarityRef": "Epic",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO049T2",
+      "09DE033"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO049.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO049-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "I: Summon <link=card.summon><style=AssociatedCard>Spritelings</style></link>.\r\nII: <link=vocab.Sleep><style=Vocab>Sleep</style></link> an ally.\r\n",
+    "descriptionRaw": "I: Summon Spritelings.\r\nII: Sleep an ally.\r\n",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Each of Mother Tree's dewdrops gives a glimpse into a dream happening somewhere in Runeterra--and each drop must be carefully harvested, nurtured, and protected.",
+    "artistName": "Envar Studio",
+    "name": "The Dewdrop Harvest",
+    "cardCode": "09IO049",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO052T2",
+      "09IO052T1",
+      "09IO052T3"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO052.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO052-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 2,
+    "cost": 3,
+    "health": 1,
+    "description": "When I'm summoned or <link=vocab.Strike><style=Vocab>Strike</style></link>: Create a <link=card.lullaby><style=AssociatedCard>Dream-Laden Bough</style></link> in hand or, if you have one, reduce its cost by 1.",
+    "descriptionRaw": "When I'm summoned or Strike: Create a Dream-Laden Bough in hand or, if you have one, reduce its cost by 1.",
+    "levelupDescription": "You've summoned 15+ allies or landmarks. <style=Variable></style>",
+    "levelupDescriptionRaw": "You've summoned 15+ allies or landmarks. ",
+    "flavorText": "At the heart of the Garden of Forgetting, the dewdrop harvest grows near. Though these dewdrops are lovingly tended by Lillia and the garden's other caretakers, a strange corruption can now be seen within them, and the dreams they show turning haunted and dark...",
+    "artistName": "Envar Studio",
+    "name": "Lillia",
+    "cardCode": "09IO052",
+    "keywords": [
+      "Quick Attack",
+      "Spirit"
+    ],
+    "keywordRefs": [
+      "QuickStrike",
+      "Spirit"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "Champion",
+    "rarityRef": "Champion",
+    "subtypes": [],
+    "supertype": "Champion",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO052T2",
+      "09IO052",
+      "09IO052T3"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO052T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO052T1-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 3,
+    "cost": 3,
+    "health": 2,
+    "description": "When I'm summoned or <link=vocab.Strike><style=Vocab>Strike</style></link>: Create a <link=card.lullaby><style=AssociatedCard>Dream-Laden Bough</style></link> in hand or, if you have one, reduce its cost by 1.\r\nWhen you <link=vocab.Sleep><style=Vocab>Sleep</style></link> another ally, immediately wake it up and grant it <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>.",
+    "descriptionRaw": "When I'm summoned or Strike: Create a Dream-Laden Bough in hand or, if you have one, reduce its cost by 1.\r\nWhen you Sleep another ally, immediately wake it up and grant it Spirit.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "...as if a twisted corruption had taken root within them, threatening to leave dreamers stranded in their own dangerous nightmares.",
+    "artistName": "Envar Studio",
+    "name": "Lillia",
+    "cardCode": "09IO052T1",
+    "keywords": [
+      "Quick Attack",
+      "Spirit"
+    ],
+    "keywordRefs": [
+      "QuickStrike",
+      "Spirit"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "Champion",
+    "rarityRef": "Champion",
+    "subtypes": [],
+    "supertype": "Champion",
+    "type": "Unit",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO045T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO052T3.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO052T3-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "<link=vocab.Sleep><style=Vocab>Sleep</style></link> an ally.",
+    "descriptionRaw": "Sleep an ally.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"I've caught a dream for you, and you, and you--all of you!\" - Lillia",
+    "artistName": "Wild Blue",
+    "name": "Dream-Laden Bough",
+    "cardCode": "09IO052T3",
+    "keywords": [
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Slow"
+    ],
+    "spellSpeed": "Slow",
+    "spellSpeedRef": "Slow",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Spell",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO052",
+      "09IO052T1",
+      "09IO045T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO052T2.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO052T2-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "<link=vocab.Sleep><style=Vocab>Sleep</style></link> a unit.\r\nCreate a <link=card.level1><style=AssociatedCard>Lillia</style></link> in your deck.",
+    "descriptionRaw": "Sleep a unit.\r\nCreate a Lillia in your deck.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Dreams are a-bloomin'!\" - Lillia",
+    "artistName": "Caravan Studio",
+    "name": "Lillia's Blooming Bud",
+    "cardCode": "09IO052T2",
+    "keywords": [
+      "Fast"
+    ],
+    "keywordRefs": [
+      "Fast"
+    ],
+    "spellSpeed": "Fast",
+    "spellSpeedRef": "Fast",
+    "rarity": "Champion",
+    "rarityRef": "Champion",
+    "subtypes": [],
+    "supertype": "Champion",
+    "type": "Spell",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO046T1",
+      "09IO045T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO046.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO046-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 2,
+    "cost": 3,
+    "health": 4,
+    "description": "<link=keyword.PlaySkillMark><sprite name=SkillMark><style=Keyword>Play</style></link>: Fully heal an ally, then <link=vocab.Sleep><style=Vocab>sleep</style></link> it.",
+    "descriptionRaw": "Play: Fully heal an ally, then sleep it.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "To care for the Dreaming Tree and the surrounding garden is a high honor, but one that requires sacrifice. In a ritual of respect and appreciation, the garden's caretakers offer up their own memories, losing a part of themselves every night.",
+    "artistName": "Envar Studio",
+    "name": "Ophelis Gardener",
+    "cardCode": "09IO046",
+    "keywords": [],
+    "keywordRefs": [],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO045T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO046T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO046T1-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Fully heal an ally, then <link=vocab.Sleep><style=Vocab>sleep</style></link> it. ",
+    "descriptionRaw": "Fully heal an ally, then sleep it. ",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Go on, little sprite! Soar!\" - Ophelis Gardener",
+    "artistName": "",
+    "name": "Garden's Gratitude",
+    "cardCode": "09IO046T1",
+    "keywords": [
+      "Skill"
+    ],
+    "keywordRefs": [
+      "Skill"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO051T4"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO051.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO051-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 4,
+    "health": 0,
+    "description": "I-II: Draw 1.\r\nIII: Reduce the cost of cards in your hand by 1 this round. ",
+    "descriptionRaw": "I-II: Draw 1.\r\nIII: Reduce the cost of cards in your hand by 1 this round. ",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "The Garden of Forgetting is home to a strange assortment of creatures both large and small--some with more sentience than they would like to have.",
+    "artistName": "Envar Studio",
+    "name": "The Rootbound Path",
+    "cardCode": "09IO051",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO051T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO051T2.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO051T2-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Reduce the cost of cards in your hand by 1 this round. ",
+    "descriptionRaw": "Reduce the cost of cards in your hand by 1 this round. ",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Everything dies, you know. Even dreams. Especially dreams. Hey, should we go for a walk?\" - Mister Root",
+    "artistName": "Envar Studio",
+    "name": "Root Canopy",
+    "cardCode": "09IO051T2",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO051"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO051T4.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO051T4-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Draw 1.",
+    "descriptionRaw": "Draw 1.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Smile through the pain!\" - Mister Root",
+    "artistName": "Envar Studio",
+    "name": "Sentient Seedling",
+    "cardCode": "09IO051T4",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO051T2"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO051T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO051T1-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 4,
+    "health": 0,
+    "description": "I - II: Draw 1.\r\nIII: Reduce the cost of cards in your hand by 1 this round. ",
+    "descriptionRaw": "I - II: Draw 1.\r\nIII: Reduce the cost of cards in your hand by 1 this round. ",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "The Garden of Forgetting is home to a strange assortment of creatures both large and small--some with more sentience than they would like to have.",
+    "artistName": "Envar Studio",
+    "name": "The Rootbound Path",
+    "cardCode": "09IO051T1",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO051T4"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO051T3.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO051T3-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 4,
+    "health": 0,
+    "description": "I - II: Draw 1.\r\nIII: Reduce the cost of cards in your hand by 1 this round. ",
+    "descriptionRaw": "I - II: Draw 1.\r\nIII: Reduce the cost of cards in your hand by 1 this round. ",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "The Garden of Forgetting is home to a strange assortment of creatures both large and small--some with more sentience than they would like to have.",
+    "artistName": "Envar Studio",
+    "name": "The Rootbound Path",
+    "cardCode": "09IO051T3",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO053.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO053-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 1,
+    "description": "When I'm summoned, draw 1.",
+    "descriptionRaw": "When I'm summoned, draw 1.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Wow, one day all of this beauty will be dead, and so will we. I hope I'm first. Hehe!\"",
+    "artistName": "Caravan Studio",
+    "name": "Mister Root",
+    "cardCode": "09IO053",
+    "keywords": [
+      "Spirit"
+    ],
+    "keywordRefs": [
+      "Spirit"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO049T4",
+      "09DE033"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO049T3.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO049T3-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "I: Summon <link=card.summon><style=AssociatedCard>Spritelings</style></link>.\r\nII: <link=vocab.Sleep><style=Vocab>Sleep</style></link> an ally.\r\n",
+    "descriptionRaw": "I: Summon Spritelings.\r\nII: Sleep an ally.\r\n",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Each of Mother Tree's dewdrops gives a glimpse into a dream happening somewhere in Runeterra--and each drop must be carefully harvested, nurtured, and protected.",
+    "artistName": "Envar Studio",
+    "name": "The Dewdrop Harvest",
+    "cardCode": "09IO049T3",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO049",
+      "09DE033"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO049T2.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO049T2-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Summon <link=card.summon><style=AssociatedCard>Spritelings</style></link>.",
+    "descriptionRaw": "Summon Spritelings.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Look, little sprite, I even brought you a clover chew.\" - Ophelis Gardener",
+    "artistName": "Envar Studio",
+    "name": "Spriteling Call",
+    "cardCode": "09IO049T2",
+    "keywords": [
+      "Skill",
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Slow"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO045T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO049T4.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO049T4-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "<link=vocab.Sleep><style=Vocab>Sleep</style></link> an ally.",
+    "descriptionRaw": "Sleep an ally.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Close your eyes to see the most wondrous of things!\" - Lillia",
+    "artistName": "Envar Studio",
+    "name": "Dreamdust Branch",
+    "cardCode": "09IO049T4",
+    "keywords": [
+      "Skill",
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Slow"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO045T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO045.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO045-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "<link=vocab.Sleep><style=Vocab>Sleep</style></link> a unit.\r\n",
+    "descriptionRaw": "Sleep a unit.\r\n",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Dreams are a-bloomin'!\" - Lillia",
+    "artistName": "Caravan Studio",
+    "name": "Blooming Bud",
+    "cardCode": "09IO045",
+    "keywords": [
+      "Fast"
+    ],
+    "keywordRefs": [
+      "Fast"
+    ],
+    "spellSpeed": "Fast",
+    "spellSpeedRef": "Fast",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Spell",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO045T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO045T1-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "<link=vocab.Countdown><style=Vocab>Countdown 1</style></link><style=Variable></style>: Summon an exact copy of the sleeping unit inside.",
+    "descriptionRaw": "Countdown 1: Summon an exact copy of the sleeping unit inside.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Daydreams, night dreams, mid-morning dreams--the Dreaming Tree has branches with paths to them all.",
+    "artistName": "Bubble Cat",
+    "name": "Drowsy Dewdrop",
+    "cardCode": "09IO045T1",
+    "keywords": [
+      "Landmark",
+      "Countdown"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly",
+      "Countdown"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO058T4",
+      "09DE033"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO058.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO058-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 7,
+    "health": 0,
+    "description": "I: Heal your Nexus 3 and summon <link=card.summon><style=AssociatedCard>Spritelings</style></link>.\r\nII: Grant allies <link=vocab.Everywhere><style=Vocab>Everywhere</style></link> <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>.\r\nIII: <link=vocab.Manifest><style=Vocab>Manifest</style></link> a card that costs 8 or more and reduce its cost by half, rounded up.",
+    "descriptionRaw": "I: Heal your Nexus 3 and summon Spritelings.\r\nII: Grant allies Everywhere Spirit.\r\nIII: Manifest a card that costs 8 or more and reduce its cost by half, rounded up.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Dream sprites are one of the Garden's more plentiful inhabitants. Varied in shape, size, and temperament, many of them will go on to enter dewdrops, guiding their dreamers towards their deepest wishes.",
+    "artistName": "Envar Studio",
+    "name": "The Heart of the Tree",
+    "cardCode": "09IO058",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "EPIC",
+    "rarityRef": "Epic",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO058T5.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO058T5-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Grant allies <link=vocab.Everywhere><style=Vocab>Everywhere</style></link> <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>.",
+    "descriptionRaw": "Grant allies Everywhere Spirit.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Oh, the sprites never set out alone.\" - Ophelis Caretaker",
+    "artistName": "Envar Studio",
+    "name": "Sprite Flock",
+    "cardCode": "09IO058T5",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09DE033"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO058T4.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO058T4-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Heal your Nexus 3 and summon <link=card.summon><style=AssociatedCard>Spritelings</style></link>.\r\n",
+    "descriptionRaw": "Heal your Nexus 3 and summon Spritelings.\r\n",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"All every plant needs is some good, fresh soil.\" - Ophelis Caretaker",
+    "artistName": "Envar Studio",
+    "name": "Green Thumb",
+    "cardCode": "09IO058T4",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO058T6",
+      "09DE033"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO058T3.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO058T3-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 7,
+    "health": 0,
+    "description": "I: Heal your Nexus 3 and summon <link=card.summon><style=AssociatedCard>Spritelings</style></link>.\r\nII: Grant allies <link=vocab.Everywhere><style=Vocab>Everywhere</style></link> <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>.\r\nIII: <link=vocab.Manifest><style=Vocab>Manifest</style></link> a card that costs 8 or more and reduce its cost by half, rounded up.",
+    "descriptionRaw": "I: Heal your Nexus 3 and summon Spritelings.\r\nII: Grant allies Everywhere Spirit.\r\nIII: Manifest a card that costs 8 or more and reduce its cost by half, rounded up.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Dream sprites are one of the Garden's more plentiful inhabitants. Varied in shape, size, and temperament, many of them will go on to enter dewdrops, guiding their dreamers towards their deepest wishes.",
+    "artistName": "Envar Studio",
+    "name": "The Heart of the Tree",
+    "cardCode": "09IO058T3",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09IO058T5",
+      "09DE033"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO058T7.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO058T7-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 7,
+    "health": 0,
+    "description": "I: Heal your Nexus 3 and summon <link=card.summon><style=AssociatedCard>Spritelings</style></link>.\r\nII: Grant allies <link=vocab.Everywhere><style=Vocab>Everywhere</style></link> <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>.\r\nIII: <link=vocab.Manifest><style=Vocab>Manifest</style></link> a card that costs 8 or more and reduce its cost by half, rounded up.",
+    "descriptionRaw": "I: Heal your Nexus 3 and summon Spritelings.\r\nII: Grant allies Everywhere Spirit.\r\nIII: Manifest a card that costs 8 or more and reduce its cost by half, rounded up.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Dream sprites are one of the Garden's more plentiful inhabitants. Varied in shape, size, and temperament, many of them will go on to enter dewdrops, guiding their dreamers towards their deepest wishes.",
+    "artistName": "Envar Studio",
+    "name": "The Heart of the Tree",
+    "cardCode": "09IO058T7",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO058T6.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO058T6-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "<link=vocab.Manifest><style=Vocab>Manifest</style></link> a card that costs 8 or more and reduce Its cost by half, rounded up.",
+    "descriptionRaw": "Manifest a card that costs 8 or more and reduce Its cost by half, rounded up.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"The sprites become exactly what their dreamer needs. Closure, peace, love--they can help you find it.\" - Ophelis Caretaker",
+    "artistName": "Envar Studio",
+    "name": "Dreamer's Guide",
+    "cardCode": "09IO058T6",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO059.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09IO059-full.png"
+      }
+    ],
+    "regions": [
+      "Ionia"
+    ],
+    "regionRefs": [
+      "Ionia"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "<link=keyword.Stun><sprite name=Stunned><style=Keyword>Stun</style></link> an enemy and <link=keyword.Stun><sprite name=Stunned><style=Keyword>Stun</style></link> it again at the next <link=vocab.RoundStart><style=Vocab>Round Start</style></link>.",
+    "descriptionRaw": "Stun an enemy and Stun it again at the next Round Start.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"The blade above all.\" - Yone Windchaser",
+    "artistName": "Wild Blue",
+    "name": "Steel Gale",
+    "cardCode": "09IO059",
+    "keywords": [
+      "Fast"
+    ],
+    "keywordRefs": [
+      "Fast"
+    ],
+    "spellSpeed": "Fast",
+    "spellSpeedRef": "Fast",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Spell",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09FR009T5"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09FR009.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09FR009-full.png"
+      }
+    ],
+    "regions": [
+      "Freljord"
+    ],
+    "regionRefs": [
+      "Freljord"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "I-II: <link=vocab.Manifest><style=Vocab>Manifest</style></link> a follower that has a different subtype than allies in play.\r\nIII: Give an ally +1|+1 this round for each ally with a subtype.",
+    "descriptionRaw": "I-II: Manifest a follower that has a different subtype than allies in play.\r\nIII: Give an ally +1|+1 this round for each ally with a subtype.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Ingvar has forged an even stronger relationship with the Poro King's subjects since her visit to his kingdom. Stampeding through the Freljord in search of adventure is one of the best ways to improve diplomatic relationships.",
+    "artistName": "Caravan Studio",
+    "name": "The Poro Parade",
+    "cardCode": "09FR009",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "EPIC",
+    "rarityRef": "Epic",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09FR009T2.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09FR009T2-full.png"
+      }
+    ],
+    "regions": [
+      "Freljord"
+    ],
+    "regionRefs": [
+      "Freljord"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Give an ally +1|+1 this round for each ally with a subtype.",
+    "descriptionRaw": "Give an ally +1|+1 this round for each ally with a subtype.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"We gotta go even fasterer!\" - Ingvar the Younger",
+    "artistName": "Caravan Studio",
+    "name": "Poro Captain",
+    "cardCode": "09FR009T2",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09FR009T5.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09FR009T5-full.png"
+      }
+    ],
+    "regions": [
+      "Freljord"
+    ],
+    "regionRefs": [
+      "Freljord"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "<link=vocab.Manifest><style=Vocab>Manifest</style></link> a follower that has a different subtype than allies in play.",
+    "descriptionRaw": "Manifest a follower that has a different subtype than allies in play.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Is that a costume, Mister Poro?\" - Ingvar the Younger",
+    "artistName": "Caravan Studio",
+    "name": "Poro Entourage",
+    "cardCode": "09FR009T5",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09FR009T2"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09FR009T3.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09FR009T3-full.png"
+      }
+    ],
+    "regions": [
+      "Freljord"
+    ],
+    "regionRefs": [
+      "Freljord"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "I-II: <link=vocab.Manifest><style=Vocab>Manifest</style></link> a follower that has a different subtype than allies in play.\r\nIII: Give an ally +1|+1 this round for each ally with a subtype.",
+    "descriptionRaw": "I-II: Manifest a follower that has a different subtype than allies in play.\r\nIII: Give an ally +1|+1 this round for each ally with a subtype.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Ingvar has forged an even stronger relationship with the Poro King's subjects since her visit to his kingdom. Stampeding through the Freljord in search of adventure is one of the best ways to improve diplomatic relationships.",
+    "artistName": "Caravan Studio",
+    "name": "The Poro Parade",
+    "cardCode": "09FR009T3",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09FR009T5",
+      "09FR009T3",
+      "09FR009"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09FR009T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09FR009T1-full.png"
+      }
+    ],
+    "regions": [
+      "Freljord"
+    ],
+    "regionRefs": [
+      "Freljord"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "I-II: <link=vocab.Manifest><style=Vocab>Manifest</style></link> a follower that has a different subtype than allies in play.\r\nIII: Give an ally +1|+1 this round for each ally with a subtype.",
+    "descriptionRaw": "I-II: Manifest a follower that has a different subtype than allies in play.\r\nIII: Give an ally +1|+1 this round for each ally with a subtype.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Ingvar has forged an even stronger relationship with the Poro King's subjects since her visit to his kingdom. Stampeding through the Freljord in search of adventure is one of the best ways to improve diplomatic relationships.",
+    "artistName": "Caravan Studio",
+    "name": "The Poro Parade",
+    "cardCode": "09FR009T1",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09FR014T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09FR014.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09FR014-full.png"
+      }
+    ],
+    "regions": [
+      "Freljord"
+    ],
+    "regionRefs": [
+      "Freljord"
+    ],
+    "attack": 3,
+    "cost": 3,
+    "health": 3,
+    "description": "<link=vocab.Play><style=Vocab>Play</style></link>: <link=vocab.Obliterate><style=Vocab>Obliterate</style></link> a unit in hand to summon a <link=card.create><style=AssociatedCard>Stormcarved Spire</style></link> that has <link=vocab.Countdown><style=Vocab>Countdown</style></link> equal to its cost and summons an exact copy of the unit. (minimum 1) ",
+    "descriptionRaw": "Play: Obliterate a unit in hand to summon a Stormcarved Spire that has Countdown equal to its cost and summons an exact copy of the unit. (minimum 1) ",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"I am forged in the storm of the mountain and the song of my people!\"",
+    "artistName": "Envar Studio",
+    "name": "Brynhir Thundersong",
+    "cardCode": "09FR014",
+    "keywords": [],
+    "keywordRefs": [],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "EPIC",
+    "rarityRef": "Epic",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09FR010.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09FR010-full.png"
+      }
+    ],
+    "regions": [
+      "Freljord"
+    ],
+    "regionRefs": [
+      "Freljord"
+    ],
+    "attack": 3,
+    "cost": 3,
+    "health": 3,
+    "description": "<link=vocab.Play><style=Vocab>Play</style></link>: Heal your Nexus 1 for each ally with a subtype.",
+    "descriptionRaw": "Play: Heal your Nexus 1 for each ally with a subtype.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Oh ho ho, look at that fluff!\" - Poro Herder",
+    "artistName": "Caravan Studio",
+    "name": "Ultrasoft Poro",
+    "cardCode": "09FR010",
+    "keywords": [],
+    "keywordRefs": [],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [
+      "PORO"
+    ],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09FR014T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09FR014T1-full.png"
+      }
+    ],
+    "regions": [
+      "Freljord"
+    ],
+    "regionRefs": [
+      "Freljord"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "<style=Variable></style><link=vocab.Countdown><style=Vocab>Countdown </style></link><style=Variable></style>: Summon an exact copy of the unit stored inside.",
+    "descriptionRaw": "Countdown : Summon an exact copy of the unit stored inside.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"To challenge nature is foolhardy. To channel it, however--therein lies power beyond measure.\" - Brynhir Thundersong",
+    "artistName": "Envar Studio",
+    "name": "Stormcarved Spire",
+    "cardCode": "09FR014T1",
+    "keywords": [
+      "Landmark",
+      "Countdown"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly",
+      "Countdown"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09FR012.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09FR012-full.png"
+      }
+    ],
+    "regions": [
+      "Freljord"
+    ],
+    "regionRefs": [
+      "Freljord"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "Grant an ally Health equal to its Power and <link=keyword.Formidable><sprite name=Formidable><style=Keyword>Formidable</style></link>, then set its Power to 0.",
+    "descriptionRaw": "Grant an ally Health equal to its Power and Formidable, then set its Power to 0.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Some trees in the Freljord can only be felled by the power of winter frost itself.",
+    "artistName": "Wild Blue",
+    "name": "Glacial Fell",
+    "cardCode": "09FR012",
+    "keywords": [
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Slow"
+    ],
+    "spellSpeed": "Slow",
+    "spellSpeedRef": "Slow",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Spell",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC020.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC020-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City",
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "BandleCity",
+      "ShadowIsles"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "Grant a unit <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link> to draw 1.",
+    "descriptionRaw": "Grant a unit Gloom to draw 1.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Congratulations. I hate you.\" - Vex",
+    "artistName": "Caravan Studio",
+    "name": "Glare",
+    "cardCode": "09BC020",
+    "keywords": [
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Slow"
+    ],
+    "spellSpeed": "Slow",
+    "spellSpeedRef": "Slow",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Spell",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BC012T2"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC012.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC012-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "I: Grant a unit <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link>.\r\nII: Grant an ally <link=keyword.Impact><sprite name=Impact><style=Keyword>Impact</style></link>.\r\nIII: <link=vocab.Boost><style=Vocab>Boost</style></link> 2 units.",
+    "descriptionRaw": "I: Grant a unit Gloom.\r\nII: Grant an ally Impact.\r\nIII: Boost 2 units.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Absence doesn't make this heart grow any fonder. But at least family dinners are quiet around here--just the way Vex likes it.",
+    "artistName": "Envar Studio",
+    "name": "The Family Reunion",
+    "cardCode": "09BC012",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "EPIC",
+    "rarityRef": "Epic",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BC012T5"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC012T4.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC012T4-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "I: Grant a unit <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link>.\r\nII: Grant an ally <link=keyword.Impact><sprite name=Impact><style=Keyword>Impact</style></link>.\r\nIII: <link=vocab.Boost><style=Vocab>Boost</style></link> 2 units.",
+    "descriptionRaw": "I: Grant a unit Gloom.\r\nII: Grant an ally Impact.\r\nIII: Boost 2 units.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Absence doesn't make this heart grow any fonder. But at least family dinners are quiet around here--just the way Vex likes it.",
+    "artistName": "Envar Studio",
+    "name": "The Family Reunion",
+    "cardCode": "09BC012T4",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BC012T3"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC012T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC012T1-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "I: Grant a unit <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link>.\r\nII: Grant an ally <link=keyword.Impact><sprite name=Impact><style=Keyword>Impact</style></link>.\r\nIII: <link=vocab.Boost><style=Vocab>Boost</style></link> 2 units.",
+    "descriptionRaw": "I: Grant a unit Gloom.\r\nII: Grant an ally Impact.\r\nIII: Boost 2 units.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Absence doesn't make this heart grow any fonder. But at least family dinners are quiet around here--just the way Vex likes it.",
+    "artistName": "Envar Studio",
+    "name": "The Family Reunion",
+    "cardCode": "09BC012T1",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BC012T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC012T3.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC012T3-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "<link=vocab.Boost><style=Vocab>Boost</style></link> 2 units.",
+    "descriptionRaw": "Boost 2 units.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"It's not a phase, Mom.\" - Vex",
+    "artistName": "Envar Studio",
+    "name": "Ms. Vex",
+    "cardCode": "09BC012T3",
+    "keywords": [
+      "Skill",
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Slow"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC012T5.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC012T5-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Grant an ally <link=keyword.Impact><sprite name=Impact><style=Keyword>Impact</style></link>.",
+    "descriptionRaw": "Grant an ally Impact.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"You guys BETTER not go to that stupid party. You stay rooted right here.\" - Vex",
+    "artistName": "Envar Studio",
+    "name": "Mr. Vex",
+    "cardCode": "09BC012T5",
+    "keywords": [
+      "Skill",
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Slow"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BC012"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC012T2.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC012T2-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Grant a unit <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link>.",
+    "descriptionRaw": "Grant a unit Gloom.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"No, I don't want to swing on your branches! I'm not a kid anymore!\" - Vex",
+    "artistName": "Envar Studio",
+    "name": "Little Gloomist",
+    "cardCode": "09BC012T2",
+    "keywords": [
+      "Skill",
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Slow"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BC001T3",
+      "09BC001T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC001.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC001-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City",
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "BandleCity",
+      "ShadowIsles"
+    ],
+    "attack": 5,
+    "cost": 4,
+    "health": 4,
+    "description": "<link=vocab.Attack><style=Vocab>Attack</style></link>: Grant the <link=vocab.Strongest><style=Vocab>Strongest</style></link> enemy <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link>.",
+    "descriptionRaw": "Attack: Grant the Strongest enemy Gloom.",
+    "levelupDescription": "You've granted <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link> 5+ different times.<style=Variable></style>",
+    "levelupDescriptionRaw": "You've granted Gloom 5+ different times.",
+    "flavorText": "\"Ugh, stupid pink girl. I already told her I HATE parties, especially when there's cake. Gross. Just... wake me up when she goes away.\"",
+    "artistName": "Envar Studio",
+    "name": "Vex",
+    "cardCode": "09BC001",
+    "keywords": [
+      "Fearsome"
+    ],
+    "keywordRefs": [
+      "Fearsome"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "Champion",
+    "rarityRef": "Champion",
+    "subtypes": [
+      "YORDLE"
+    ],
+    "supertype": "Champion",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BC001T1",
+      "09BC001"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC001T3.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC001T3-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City",
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "BandleCity",
+      "ShadowIsles"
+    ],
+    "attack": 6,
+    "cost": 4,
+    "health": 5,
+    "description": "<link=vocab.Attack><style=Vocab>Attack</style></link>: Grant the <link=vocab.Strongest><style=Vocab>strongest</style></link> enemy <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link>.\r\nWhen an enemy gains <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link>, it gains it again.",
+    "descriptionRaw": "Attack: Grant the strongest enemy Gloom.\r\nWhen an enemy gains Gloom, it gains it again.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Well, this is awful. And not in a good way.\"",
+    "artistName": "Envar Studio",
+    "name": "Vex",
+    "cardCode": "09BC001T3",
+    "keywords": [
+      "Fearsome"
+    ],
+    "keywordRefs": [
+      "Fearsome"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "Champion",
+    "rarityRef": "Champion",
+    "subtypes": [
+      "YORDLE"
+    ],
+    "supertype": "Champion",
+    "type": "Unit",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BC001",
+      "09BC001T3"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC001T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC001T1-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City",
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "BandleCity",
+      "ShadowIsles"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "Grant a unit <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link> to draw 1.\r\nCreate a <link=card.level1><style=AssociatedCard>Vex</style></link> in your deck.",
+    "descriptionRaw": "Grant a unit Gloom to draw 1.\r\nCreate a Vex in your deck.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Congratulations. I hate you.\" - Vex",
+    "artistName": "Caravan Studio",
+    "name": "Vex's Glare",
+    "cardCode": "09BC001T1",
+    "keywords": [
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Slow"
+    ],
+    "spellSpeed": "Slow",
+    "spellSpeedRef": "Slow",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "Champion",
+    "type": "Spell",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC002.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC002-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 2,
+    "cost": 2,
+    "health": 2,
+    "description": "Grant me 2 <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link> once you've completed a Story.",
+    "descriptionRaw": "Grant me 2 Spirit once you've completed a Story.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Though he's certainly very different from his gloomy niece, Uncle Milty always does his best to connect with her--especially if it's through a spooky story told by candlelight.",
+    "artistName": "Envar Studio",
+    "name": "Uncle Milty",
+    "cardCode": "09BC002",
+    "keywords": [
+      "Impact"
+    ],
+    "keywordRefs": [
+      "Impact"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [
+      "YORDLE"
+    ],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BC013T4"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC013.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC013-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "I-II: Pick an ally, then pick 1 of 3 followers that costs 1 more to transform it into.\r\nIII: Pick an ally, then pick 1 of 3 followers that costs 2 more to transform it into.",
+    "descriptionRaw": "I-II: Pick an ally, then pick 1 of 3 followers that costs 1 more to transform it into.\r\nIII: Pick an ally, then pick 1 of 3 followers that costs 2 more to transform it into.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Old Trevor Snoozebottom always seems to find himself drifting about in some dream or another. This one, thankfully, seems quite peaceful... though, strangely, everyone he comes across wants wings just like his...",
+    "artistName": "Envar Studio",
+    "name": "The Wingsgiving",
+    "cardCode": "09BC013",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC013T4.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC013T4-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Pick an ally, then pick 1 of 3 followers that costs 1 more to transform it into.",
+    "descriptionRaw": "Pick an ally, then pick 1 of 3 followers that costs 1 more to transform it into.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Poros, berries... pudding soup...\" - Trevor Snoozebottom",
+    "artistName": "Envar Studio",
+    "name": "Forest Friends",
+    "cardCode": "09BC013T4",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BC013T4"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC013T2.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC013T2-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "I-II: Pick an ally, then pick 1 of 3 followers that costs 1 more to transform it into.\r\nIII: Pick an ally, then pick 1 of 3 followers that costs 2 more to transform it into.",
+    "descriptionRaw": "I-II: Pick an ally, then pick 1 of 3 followers that costs 1 more to transform it into.\r\nIII: Pick an ally, then pick 1 of 3 followers that costs 2 more to transform it into.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Old Trevor Snoozebottom always seems to find himself drifting about in some dream or another. This one, thankfully, seems quite peaceful... though, strangely, everyone he comes across wants wings just like his...",
+    "artistName": "Envar Studio",
+    "name": "The Wingsgiving",
+    "cardCode": "09BC013T2",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BC013T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC013T3.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC013T3-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "I-II: Pick an ally, then pick 1 of 3 followers that costs 1 more to transform it into.\r\nIII: Pick an ally, then pick 1 of 3 followers that costs 2 more to transform it into.",
+    "descriptionRaw": "I-II: Pick an ally, then pick 1 of 3 followers that costs 1 more to transform it into.\r\nIII: Pick an ally, then pick 1 of 3 followers that costs 2 more to transform it into.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Old Trevor Snoozebottom always seems to find himself drifting about in some dream or another. This one, thankfully, seems quite peaceful... though, strangely, everyone he comes across wants wings just like his...",
+    "artistName": "Envar Studio",
+    "name": "The Wingsgiving",
+    "cardCode": "09BC013T3",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC013T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC013T1-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Pick an ally, then pick 1 of 3 followers that costs 2 more to transform it into.",
+    "descriptionRaw": "Pick an ally, then pick 1 of 3 followers that costs 2 more to transform it into.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Wings, ah, yes... they should all have wings!\" - Trevor Snoozebottom",
+    "artistName": "Envar Studio",
+    "name": "Snoozebottom's Bequest",
+    "cardCode": "09BC013T1",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BC004T7"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC004.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC004-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 2,
+    "cost": 3,
+    "health": 2,
+    "description": "<link=vocab.Play><style=Vocab>Play</style></link>: Grant me <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link> or <link=keyword.PlaySkillMark><sprite name=SkillMark><style=Keyword></style></link>Grant a unit <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link>.",
+    "descriptionRaw": "Play: Grant me Spirit or Grant a unit Gloom.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Veeeee! Waaait! I have something for you! It's an invitation to your very own BIRTHDAY PARTY! And your gift, a little early! I COULDN'T wait. Aren't you excited? We need to talk about what to wear, and the CAKE, and--Vee?\"",
+    "artistName": "Envar Studio",
+    "name": "Allay",
+    "cardCode": "09BC004",
+    "keywords": [
+      "Impact"
+    ],
+    "keywordRefs": [
+      "Impact"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [
+      "YORDLE"
+    ],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC004T5.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC004T5-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 2,
+    "cost": 3,
+    "health": 2,
+    "description": "<link=vocab.Play><style=Vocab>Play</style></link> Grant me <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>.",
+    "descriptionRaw": "Play Grant me Spirit.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Veeeee! Waaait! I have something for you! It's an invitation to your very own BIRTHDAY PARTY! And your gift, a little early! I COULDN'T wait. Aren't you excited? We need to talk about what to wear, and the CAKE, and--Vee?\"",
+    "artistName": "Envar Studio",
+    "name": "Allay",
+    "cardCode": "09BC004T5",
+    "keywords": [
+      "Impact"
+    ],
+    "keywordRefs": [
+      "Impact"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [
+      "YORDLE"
+    ],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BC004T7"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC004T6.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC004T6-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 2,
+    "cost": 3,
+    "health": 2,
+    "description": "<link=keyword.PlaySkillMark><sprite name=SkillMark><style=Keyword>Play</style></link>: Grant a unit <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link>.",
+    "descriptionRaw": "Play: Grant a unit Gloom.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Veeeee! Waaait! I have something for you! It's an invitation to your very own BIRTHDAY PARTY! And your gift, a little early! I COULDN'T wait. Aren't you excited? We need to talk about what to wear, and the CAKE, and--Vee?\"",
+    "artistName": "Envar Studio",
+    "name": "Allay",
+    "cardCode": "09BC004T6",
+    "keywords": [
+      "Impact"
+    ],
+    "keywordRefs": [
+      "Impact"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [
+      "YORDLE"
+    ],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC004T7.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC004T7-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Grant a unit <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link>.",
+    "descriptionRaw": "Grant a unit Gloom.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"It's still not my birthday.\" - Vex",
+    "artistName": "Envar Studio",
+    "name": "Irritating Invite",
+    "cardCode": "09BC004T7",
+    "keywords": [
+      "Skill"
+    ],
+    "keywordRefs": [
+      "Skill"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC016.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC016-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "Grow an ally's Power or Health to 5 this round.",
+    "descriptionRaw": "Grow an ally's Power or Health to 5 this round.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Worst. Gift. Ever.\" - Vex",
+    "artistName": "Wild Blue",
+    "name": "Monstrous Eruption",
+    "cardCode": "09BC016",
+    "keywords": [
+      "Burst"
+    ],
+    "keywordRefs": [
+      "Burst"
+    ],
+    "spellSpeed": "Burst",
+    "spellSpeedRef": "Burst",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Spell",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC016T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC016T1-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "Grow an ally's Power to 5 this round.",
+    "descriptionRaw": "Grow an ally's Power to 5 this round.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Worst. Gift. Ever.\" - Vex",
+    "artistName": "Wild Blue",
+    "name": "Monstrous Eruption",
+    "cardCode": "09BC016T1",
+    "keywords": [
+      "Burst"
+    ],
+    "keywordRefs": [
+      "Burst"
+    ],
+    "spellSpeed": "Burst",
+    "spellSpeedRef": "Burst",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Spell",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC016T2.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC016T2-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "Grow an ally's Health to 5 this round.",
+    "descriptionRaw": "Grow an ally's Health to 5 this round.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Worst. Gift. Ever.\" - Vex",
+    "artistName": "Wild Blue",
+    "name": "Monstrous Eruption",
+    "cardCode": "09BC016T2",
+    "keywords": [
+      "Burst"
+    ],
+    "keywordRefs": [
+      "Burst"
+    ],
+    "spellSpeed": "Burst",
+    "spellSpeedRef": "Burst",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Spell",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC003.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC003-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 1,
+    "cost": 2,
+    "health": 1,
+    "description": "The first time an enemy is summoned, grant it <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link>.",
+    "descriptionRaw": "The first time an enemy is summoned, grant it Gloom.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Huh, didn't end up being such a bad gift after all.\" - Vex",
+    "artistName": "Envar Studio",
+    "name": "Grotesque Gift",
+    "cardCode": "09BC003",
+    "keywords": [
+      "Spirit"
+    ],
+    "keywordRefs": [
+      "Spirit"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BC001"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC018.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC018-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City",
+      "Shadow Isles"
+    ],
+    "regionRefs": [
+      "BandleCity",
+      "ShadowIsles"
+    ],
+    "attack": 2,
+    "cost": 5,
+    "health": 5,
+    "description": "When I'm summoned, draw <link=card.champ1><style=AssociatedCard>Vex</style></link>.\r\nI have +1|+0 for each different time you've granted <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link> this game.",
+    "descriptionRaw": "When I'm summoned, draw Vex.\r\nI have +1|+0 for each different time you've granted Gloom this game.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Yeah, show them, Shadow! No presents, no confetti, and ESPECIALLY no party hats.\" - Vex",
+    "artistName": "Envar Studio",
+    "name": "Shadow",
+    "cardCode": "09BC018",
+    "keywords": [
+      "Fearsome"
+    ],
+    "keywordRefs": [
+      "Fearsome"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "EPIC",
+    "rarityRef": "Epic",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC011.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC011-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 2,
+    "cost": 1,
+    "health": 2,
+    "description": "<link=vocab.Strike><style=Vocab> Strike</style></link>: Grant me <link=keyword.Impact><sprite name=Impact><style=Keyword>Impact</style></link>.",
+    "descriptionRaw": " Strike: Grant me Impact.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Dreams have a funny way of changin' the sprites. These ones seem to be... oh, is that cake?\" - Lillia",
+    "artistName": "Envar Studio",
+    "name": "Gloomsprites",
+    "cardCode": "09BC011",
+    "keywords": [],
+    "keywordRefs": [],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC006.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BC006-full.png"
+      }
+    ],
+    "regions": [
+      "Bandle City"
+    ],
+    "regionRefs": [
+      "BandleCity"
+    ],
+    "attack": 3,
+    "cost": 4,
+    "health": 4,
+    "description": "<link=vocab.RoundStart><style=Vocab>Round Start</style></link>: <link=vocab.Boost><style=Vocab>Boost</style></link> me.",
+    "descriptionRaw": "Round Start: Boost me.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Time slowed down as the weirdly muscular mayor burst out of the impossibly tall cake. \"A very HAAAAPPYYYY BIRTHDAY,\" the mayor said with a flex, \"from Bandle's best--and buffest--elected official!\"<br><br>Out of all her dreams, Vex hated this one the most. ",
+    "artistName": "Envar Studio",
+    "name": "Beefcake Mayor",
+    "cardCode": "09BC006",
+    "keywords": [
+      "Impact"
+    ],
+    "keywordRefs": [
+      "Impact"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [
+      "YORDLE"
+    ],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BW022T2",
+      "07IO011T5"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BW022.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BW022-full.png"
+      }
+    ],
+    "regions": [
+      "Bilgewater"
+    ],
+    "regionRefs": [
+      "Bilgewater"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "I: An ally and an enemy <link=vocab.Strike><style=Vocab>Strike</style></link> each other. They can't drop below 1 Health from this <link=vocab.Strike><style=Vocab>Strike</style></link>.\r\nII: Fully heal an ally.\r\nIII: Create 3 <link=card.create><style=AssociatedCard>Coins</style></link> in hand.",
+    "descriptionRaw": "I: An ally and an enemy Strike each other. They can't drop below 1 Health from this Strike.\r\nII: Fully heal an ally.\r\nIII: Create 3 Coins in hand.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Angel has spent years angling to win the fight to end all fights. Every night, she dreams of a coin pile big enough to fill Bilgewater Bay. That's potato farm money, that is.",
+    "artistName": "Caravan Studio",
+    "name": "The Pit Champion",
+    "cardCode": "09BW022",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "EPIC",
+    "rarityRef": "Epic",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BW028.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BW028-full.png"
+      }
+    ],
+    "regions": [
+      "Bilgewater"
+    ],
+    "regionRefs": [
+      "Bilgewater"
+    ],
+    "attack": 0,
+    "cost": 1,
+    "health": 1,
+    "description": "I have +1|+0 for each card you've drawn this round.",
+    "descriptionRaw": "I have +1|+0 for each card you've drawn this round.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"What do you mean I 'need more training'? I've BEEN training--look, look!\"",
+    "artistName": "Envar Studio",
+    "name": "Eager Dedicant",
+    "cardCode": "09BW028",
+    "keywords": [
+      "Brash",
+      "Missing Translation"
+    ],
+    "keywordRefs": [
+      "Brash",
+      "AuraVisualFakeKeyword"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BW022T5",
+      "07IO011T5"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BW022T3.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BW022T3-full.png"
+      }
+    ],
+    "regions": [
+      "Bilgewater"
+    ],
+    "regionRefs": [
+      "Bilgewater"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Create 3 <link=card.create><style=AssociatedCard>Coins</style></link>.",
+    "descriptionRaw": "Create 3 Coins.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Nothin' prettier than the glint of gold.\" - Angel",
+    "artistName": "Caravan Studio",
+    "name": "Prize Pool",
+    "cardCode": "09BW022T3",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BW022T3",
+      "07IO011T5"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BW022T5.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BW022T5-full.png"
+      }
+    ],
+    "regions": [
+      "Bilgewater"
+    ],
+    "regionRefs": [
+      "Bilgewater"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "I: An ally and an enemy <link=vocab.Strike><style=Vocab>Strike</style></link> each other. They can't drop below 1 Health from this <link=vocab.Strike><style=Vocab>Strike</style></link>.\r\nII: Fully heal an ally.\r\nIII: Create 3 <link=card.create><style=AssociatedCard>Coins</style></link> in hand.",
+    "descriptionRaw": "I: An ally and an enemy Strike each other. They can't drop below 1 Health from this Strike.\r\nII: Fully heal an ally.\r\nIII: Create 3 Coins in hand.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Angel has spent years angling to win the fight to end all fights. Every night, she dreams of a coin pile big enough to fill Bilgewater Bay. That's potato farm money, that is.",
+    "artistName": "Caravan Studio",
+    "name": "The Pit Champion",
+    "cardCode": "09BW022T5",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BW022T4",
+      "07IO011T5"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BW022T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BW022T1-full.png"
+      }
+    ],
+    "regions": [
+      "Bilgewater"
+    ],
+    "regionRefs": [
+      "Bilgewater"
+    ],
+    "attack": 0,
+    "cost": 2,
+    "health": 0,
+    "description": "I: An ally and an enemy <link=vocab.Strike><style=Vocab>Strike</style></link> each other. They can't drop below 1 Health from this <link=vocab.Strike><style=Vocab>Strike</style></link>.\r\nII: Fully heal an ally.\r\nIII: Create 3 <link=card.create><style=AssociatedCard>Coins</style></link> in hand.",
+    "descriptionRaw": "I: An ally and an enemy Strike each other. They can't drop below 1 Health from this Strike.\r\nII: Fully heal an ally.\r\nIII: Create 3 Coins in hand.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Angel has spent years angling to win the fight to end all fights. Every night, she dreams of a coin pile big enough to fill Bilgewater Bay. That's potato farm money, that is.",
+    "artistName": "Caravan Studio",
+    "name": "The Pit Champion",
+    "cardCode": "09BW022T1",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BW022T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BW022T4.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BW022T4-full.png"
+      }
+    ],
+    "regions": [
+      "Bilgewater"
+    ],
+    "regionRefs": [
+      "Bilgewater"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Fully heal an ally.",
+    "descriptionRaw": "Fully heal an ally.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Money can't buy happiness, but it sure pays for my healer.\" - Angel",
+    "artistName": "Caravan Studio",
+    "name": "Second Wind",
+    "cardCode": "09BW022T4",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09BW022"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BW022T2.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BW022T2-full.png"
+      }
+    ],
+    "regions": [
+      "Bilgewater"
+    ],
+    "regionRefs": [
+      "Bilgewater"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "An ally and an enemy <link=vocab.Strike><style=Vocab>Strike</style></link> each other. They can't drop below 1 Health from this <link=vocab.Strike><style=Vocab>Strike</style></link>.\r\n",
+    "descriptionRaw": "An ally and an enemy Strike each other. They can't drop below 1 Health from this Strike.\r\n",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Let's make it look good for the fans, yeah?\" - Angel",
+    "artistName": "Caravan Studio",
+    "name": "Convincing Clash",
+    "cardCode": "09BW022T2",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BW027.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09BW027-full.png"
+      }
+    ],
+    "regions": [
+      "Bilgewater"
+    ],
+    "regionRefs": [
+      "Bilgewater"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "Steal an enemy follower with 3 or less Health this round. (Can't play if you have 6 allies or landmarks already.)",
+    "descriptionRaw": "Steal an enemy follower with 3 or less Health this round. (Can't play if you have 6 allies or landmarks already.)",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Blood for gold is always a good start to the day.\" - Hired Gun",
+    "artistName": "Wild Blue",
+    "name": "Mercenary Manners",
+    "cardCode": "09BW027",
+    "keywords": [
+      "Slow"
+    ],
+    "keywordRefs": [
+      "Slow"
+    ],
+    "spellSpeed": "Slow",
+    "spellSpeedRef": "Slow",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Spell",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09MT002T2"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09MT002.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09MT002-full.png"
+      }
+    ],
+    "regions": [
+      "Targon"
+    ],
+    "regionRefs": [
+      "Targon"
+    ],
+    "attack": 0,
+    "cost": 5,
+    "health": 0,
+    "description": "I-II: To activate, discard 1. <link=keyword.Invoke><style=Keyword>Invoke</style></link> a Celestial card that costs 7 or more.\r\nIII: Reduce the cost of a random card in hand by 5.",
+    "descriptionRaw": "I-II: To activate, discard 1. Invoke a Celestial card that costs 7 or more.\r\nIII: Reduce the cost of a random card in hand by 5.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "This lone Ottrani is dedicated to the worship and adoration of dragons--so much that they see the regal beasts in worlds both waking and asleep.",
+    "artistName": "Wild Blue",
+    "name": "The Smokescaled Host",
+    "cardCode": "09MT002",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "EPIC",
+    "rarityRef": "Epic",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09MT002"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09MT002T4.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09MT002T4-full.png"
+      }
+    ],
+    "regions": [
+      "Targon"
+    ],
+    "regionRefs": [
+      "Targon"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Reduce the cost of a random card in hand by 5.",
+    "descriptionRaw": "Reduce the cost of a random card in hand by 5.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"A dragon's fire is sometimes beauty, and sometimes fury.\" - Ottrani Dragon-Worshiper",
+    "artistName": "Wild Blue",
+    "name": "Dragon Dedicant",
+    "cardCode": "09MT002T4",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09MT002T4"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09MT002T3.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09MT002T3-full.png"
+      }
+    ],
+    "regions": [
+      "Targon"
+    ],
+    "regionRefs": [
+      "Targon"
+    ],
+    "attack": 0,
+    "cost": 5,
+    "health": 0,
+    "description": "I-II: To activate, discard 1. <link=keyword.Invoke><style=Keyword>Invoke</style></link> a Celestial card that costs 7 or more.\r\nIII: Reduce the cost of a random card in hand by 5.",
+    "descriptionRaw": "I-II: To activate, discard 1. Invoke a Celestial card that costs 7 or more.\r\nIII: Reduce the cost of a random card in hand by 5.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "This lone Ottrani is dedicated to the worship and adoration of dragons--so much that they see the regal beasts in worlds both waking and asleep.",
+    "artistName": "Wild Blue",
+    "name": "The Smokescaled Host",
+    "cardCode": "09MT002T3",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09MT002T2"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09MT002T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09MT002T1-full.png"
+      }
+    ],
+    "regions": [
+      "Targon"
+    ],
+    "regionRefs": [
+      "Targon"
+    ],
+    "attack": 0,
+    "cost": 5,
+    "health": 0,
+    "description": "I-II: To activate, discard 1. <link=keyword.Invoke><style=Keyword>Invoke</style></link> a Celestial card that costs 7 or more.\r\nIII: Reduce the cost of a random card in hand by 5.",
+    "descriptionRaw": "I-II: To activate, discard 1. Invoke a Celestial card that costs 7 or more.\r\nIII: Reduce the cost of a random card in hand by 5.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "This lone Ottrani is dedicated to the worship and adoration of dragons--so much that they see the regal beasts in worlds both waking and asleep.",
+    "artistName": "Wild Blue",
+    "name": "The Smokescaled Host",
+    "cardCode": "09MT002T1",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09MT002"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09MT002T2.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09MT002T2-full.png"
+      }
+    ],
+    "regions": [
+      "Targon"
+    ],
+    "regionRefs": [
+      "Targon"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "To play, discard 1. <link=keyword.Invoke><style=Keyword>Invoke</style></link> a Celestial card that costs 7 or more.",
+    "descriptionRaw": "To play, discard 1. Invoke a Celestial card that costs 7 or more.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"They show themselves to me in the smoke.\" - Ottrani Dragon-Worshiper",
+    "artistName": "Wild Blue",
+    "name": "Smoke Visions",
+    "cardCode": "09MT002T2",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09MT004.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09MT004-full.png"
+      }
+    ],
+    "regions": [
+      "Targon"
+    ],
+    "regionRefs": [
+      "Targon"
+    ],
+    "attack": 0,
+    "cost": 3,
+    "health": 0,
+    "description": "Grant an ally 2 <link=keyword.Spirit><sprite name=Spirit><style=Keyword>Spirit</style></link>.",
+    "descriptionRaw": "Grant an ally 2 Spirit.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"I will be their sanctuary.\" - Morgana",
+    "artistName": "Caravan Studio",
+    "name": "Veiled Blessings",
+    "cardCode": "09MT004",
+    "keywords": [
+      "Burst"
+    ],
+    "keywordRefs": [
+      "Burst"
+    ],
+    "spellSpeed": "Burst",
+    "spellSpeedRef": "Burst",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Spell",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "02IO003T1"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09MT005.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09MT005-full.png"
+      }
+    ],
+    "regions": [
+      "Targon"
+    ],
+    "regionRefs": [
+      "Targon"
+    ],
+    "attack": 2,
+    "cost": 3,
+    "health": 3,
+    "description": "Each round, the first time you <link=keyword.Invoke><style=Keyword>Invoke</style></link>, summon a <link=card.summon><style=AssociatedCard>Dragonling</style></link>.",
+    "descriptionRaw": "Each round, the first time you Invoke, summon a Dragonling.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"The dragons are near. I can feel it. Even now, they drift through my dreams.\"",
+    "artistName": "Wild Blue",
+    "name": "Dragonsong Dreamer",
+    "cardCode": "09MT005",
+    "keywords": [],
+    "keywordRefs": [],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "EPIC",
+    "rarityRef": "Epic",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09NX025T2"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09NX025.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09NX025-full.png"
+      }
+    ],
+    "regions": [
+      "Noxus"
+    ],
+    "regionRefs": [
+      "Noxus"
+    ],
+    "attack": 0,
+    "cost": 1,
+    "health": 0,
+    "description": "I-II: Give an ally +2|+0 this round.\r\nIII: Give an enemy <link=keyword.Reckless><sprite name=Reckless><style=Keyword>Can't Block</style></link> this round.",
+    "descriptionRaw": "I-II: Give an ally +2|+0 this round.\r\nIII: Give an enemy Can't Block this round.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "The arena's popularity is due in part to the fact that anyone can make a name for themselves within it. This particular fan has watched every one of Draven's matches he could--he is sure that given the same chance, he too could rise to the top.",
+    "artistName": "Envar Studio",
+    "name": "The Arena's Greatest",
+    "cardCode": "09NX025",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "EPIC",
+    "rarityRef": "Epic",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09NX025T4.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09NX025T4-full.png"
+      }
+    ],
+    "regions": [
+      "Noxus"
+    ],
+    "regionRefs": [
+      "Noxus"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Give an enemy <link=keyword.Reckless><sprite name=Reckless><style=Keyword>Can't Block</style></link> this round.",
+    "descriptionRaw": "Give an enemy Can't Block this round.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"If only Draven could see me now!\" - Draven's Biggest Fan",
+    "artistName": "Envar Studio",
+    "name": "Slingshot Sniper",
+    "cardCode": "09NX025T4",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09NX025T2.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09NX025T2-full.png"
+      }
+    ],
+    "regions": [
+      "Noxus"
+    ],
+    "regionRefs": [
+      "Noxus"
+    ],
+    "attack": 0,
+    "cost": 0,
+    "health": 0,
+    "description": "Give an ally +2|+0 this round.\r\n",
+    "descriptionRaw": "Give an ally +2|+0 this round.\r\n",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "\"Got a rock with your name on it, pal!\" - Draven's Biggest Fan",
+    "artistName": "Envar Studio",
+    "name": "Arena Spoils",
+    "cardCode": "09NX025T2",
+    "keywords": [
+      "Skill",
+      "Focus"
+    ],
+    "keywordRefs": [
+      "Skill",
+      "Focus"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "COMMON",
+    "rarityRef": "Common",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Ability",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09NX025T2"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09NX025T1.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09NX025T1-full.png"
+      }
+    ],
+    "regions": [
+      "Noxus"
+    ],
+    "regionRefs": [
+      "Noxus"
+    ],
+    "attack": 0,
+    "cost": 1,
+    "health": 0,
+    "description": "I-II. Give an ally +2|+0 this round.\r\nIII. Give an enemy <link=keyword.Reckless><sprite name=Reckless><style=Keyword>Can't Block</style></link> this round.",
+    "descriptionRaw": "I-II. Give an ally +2|+0 this round.\r\nIII. Give an enemy Can't Block this round.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "The arena's popularity is due in part to the fact that anyone can make a name for themselves within it. This particular fan has watched every one of Draven's matches he could--he is sure that given the same chance, he too could rise to the top.",
+    "artistName": "Envar Studio",
+    "name": "The Arena's Greatest",
+    "cardCode": "09NX025T1",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "09NX025T4"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09NX025T3.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09NX025T3-full.png"
+      }
+    ],
+    "regions": [
+      "Noxus"
+    ],
+    "regionRefs": [
+      "Noxus"
+    ],
+    "attack": 0,
+    "cost": 1,
+    "health": 0,
+    "description": "I-II. Give an ally +2|+0 this round.\r\nIII. Give an enemy <link=keyword.Reckless><sprite name=Reckless><style=Keyword>Can't Block</style></link> this round.",
+    "descriptionRaw": "I-II. Give an ally +2|+0 this round.\r\nIII. Give an enemy Can't Block this round.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "The arena's popularity is due in part to the fact that anyone can make a name for themselves within it. This particular fan has watched every one of Draven's matches he could--he is sure that given the same chance, he too could rise to the top.",
+    "artistName": "Envar Studio",
+    "name": "The Arena's Greatest",
+    "cardCode": "09NX025T3",
+    "keywords": [
+      "Landmark"
+    ],
+    "keywordRefs": [
+      "LandmarkVisualOnly"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "None",
+    "rarityRef": "None",
+    "subtypes": [
+      "STORY"
+    ],
+    "supertype": "",
+    "type": "Landmark",
+    "collectible": false,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [
+      "01FR028"
+    ],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09NX032.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09NX032-full.png"
+      }
+    ],
+    "regions": [
+      "Noxus"
+    ],
+    "regionRefs": [
+      "Noxus"
+    ],
+    "attack": 1,
+    "cost": 4,
+    "health": 2,
+    "description": "To play me, discard 1. \r\nWhen I'm summoned, summon an <link=card.create><style=AssociatedCard>Enraged Yeti</style></link>.",
+    "descriptionRaw": "To play me, discard 1. \r\nWhen I'm summoned, summon an Enraged Yeti.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "The Noxian war machine's success is due in part to its flexibility. When challenging terrain or difficult conditions demand adaptation, the military will take advantage of even the most unlikely local resources.",
+    "artistName": "Envar Studio",
+    "name": "Yeti Handler",
+    "cardCode": "09NX032",
+    "keywords": [],
+    "keywordRefs": [],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Unit",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  },
+  {
+    "associatedCards": [],
+    "associatedCardRefs": [],
+    "assets": [
+      {
+        "gameAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09NX033.png",
+        "fullAbsolutePath": "http://dd.b.pvp.net/5_4_0/set9/en_us/img/cards/09NX033-full.png"
+      }
+    ],
+    "regions": [
+      "Noxus"
+    ],
+    "regionRefs": [
+      "Noxus"
+    ],
+    "attack": 3,
+    "cost": 2,
+    "health": 3,
+    "description": "<link=vocab.RoundEnd><style=Vocab>Round End</style></link>: If my bearer didn't attack this round, grant it <link=keyword.Gloom><sprite name=Gloom><style=Keyword>Gloom</style></link>.",
+    "descriptionRaw": "Round End: If my bearer didn't attack this round, grant it Gloom.",
+    "levelupDescription": "",
+    "levelupDescriptionRaw": "",
+    "flavorText": "Cowardice is costly.",
+    "artistName": "Caravan Studio",
+    "name": "Blighted Battleaxe",
+    "cardCode": "09NX033",
+    "keywords": [
+      "Equipment",
+      "Can't Block"
+    ],
+    "keywordRefs": [
+      "Equipment",
+      "CantBlock"
+    ],
+    "spellSpeed": "",
+    "spellSpeedRef": "",
+    "rarity": "RARE",
+    "rarityRef": "Rare",
+    "subtypes": [],
+    "supertype": "",
+    "type": "Equipment",
+    "collectible": true,
+    "set": "Set9",
+    "formats": [
+      "Commons Only",
+      "Eternal",
+      "Even Cost Cards",
+      "Singleton",
+      "Standard"
+    ],
+    "formatRefs": [
+      "client_Formats_CommonsOnly_name",
+      "client_Formats_Eternal_name",
+      "client_Formats_EvenCostCards_name",
+      "client_Deckbuilder_RulesFilters_Singleton",
+      "client_Formats_Standard_name"
+    ]
+  }
+]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,6 +24,7 @@ set_6cde_json = JSON.parse(
 set_7_json = JSON.parse(File.read("db/data/set7.json"), symbolize_names: true)
 set_7b_json = JSON.parse(File.read("db/data/set7b.json"), symbolize_names: true)
 set_8_json = JSON.parse(File.read("db/data/set8.json"), symbolize_names: true)
+set_9_json = JSON.parse(File.read("db/data/set9.json"), symbolize_names: true)
 
 sets = [
   set_1_json,
@@ -35,7 +36,8 @@ sets = [
   set_6cde_json,
   set_7_json,
   set_7b_json,
-  set_8_json
+  set_8_json,
+  set_9_json
 ]
 
 sets.each do |set|

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Card, type: :model do
 
   describe "#random_cards" do
     before(:each) do
-      (1..2368).each do |num|
+      (1..10).each do |num|
         create(:card, id: num)
       end
     end

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -1,16 +1,17 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Card, type: :model do
-  describe 'Search' do
+  describe "Search" do
     before(:each) do
       @card1 = create(:card, name: "Draven")
-      @card2 = create(:card, name: "Draven's Whirling Death", description: "whirling axe")
+      @card2 = create(:card, name: "Draven's Whirling Death",
+                             description: "whirling axe")
       @card3 = create(:card, name: "Potato", description: "whirling axe")
       create_list(:card, 3, name: "Draven")
       create_list(:card, 3, name: "Draven", description: "axe")
     end
 
-    it 'returns all cards with fuzzy name matches when a basic search is used' do
+    it "returns all cards with fuzzy name matches when a basic search is used" do
       search_array = [{ name: "drav" }]
 
       cards = Card.search(search_array)
@@ -44,7 +45,8 @@ RSpec.describe Card, type: :model do
     end
 
     it "returns all cards that satisfy ALL search parameters when multiple of the same search stynax is used and not just the last of that syntax" do
-      temp_card = create(:card, name: "Darius's Whirling Death", description: "whirling axe")
+      temp_card = create(:card, name: "Darius's Whirling Death",
+                                description: "whirling axe")
       search_array = [{ name: "dar" }, { name: "whirl" }]
 
       cards = Card.search(search_array)
@@ -53,6 +55,31 @@ RSpec.describe Card, type: :model do
       expect(cards.count).to eq(1)
       expect(cards).to include(temp_card)
       expect(cards).to_not include(@card2)
+    end
+  end
+
+  describe "#random_cards" do
+    before(:each) do
+      (1..2368).each do |num|
+        create(:card, id: num)
+      end
+    end
+
+    it "can return a single random card" do
+      card = Card.random_cards(1)
+
+      expect(card).to be_a Card
+
+      different_card = Card.random_cards(1)
+
+      expect(card).to_not eq(different_card)
+    end
+
+    it 'can return multiple random cards' do
+      cards = Card.random_cards(5)
+
+      expect(cards.count).to eq(5)
+      expect(cards).to all be_a Card
     end
   end
 end

--- a/spec/requests/api/v1/cards_request_spec.rb
+++ b/spec/requests/api/v1/cards_request_spec.rb
@@ -658,8 +658,8 @@ RSpec.describe Api::V1::CardsController, type: :request do
     end
   end
 
-  describe 'GET /api/v1/cards/random' do
-    it 'returns a random card' do
+  describe "GET /api/v1/cards/random" do
+    it "returns a random card" do
       get "/api/v1/cards/random"
 
       parsed_card = JSON.parse(response.body, symbolize_names: true)[:data]
@@ -667,7 +667,7 @@ RSpec.describe Api::V1::CardsController, type: :request do
       expect(response).to be_successful
       expect(response.status).to eq(200)
 
-      expect(parsed_card[:type]).to eq('card')
+      expect(parsed_card[:type]).to eq("card")
 
       card_attributes = parsed_card[:attributes]
 
@@ -676,7 +676,7 @@ RSpec.describe Api::V1::CardsController, type: :request do
       expect(card_attributes).to have_key(:description)
     end
 
-    it 'accepts a query parameter of limit that lets you return multiple random cards up to the limit' do
+    it "accepts a query parameter of limit that lets you return multiple random cards up to the limit" do
       get "/api/v1/cards/random?limit=2"
 
       parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
@@ -687,47 +687,7 @@ RSpec.describe Api::V1::CardsController, type: :request do
       expect(parsed_cards.count).to eq(2)
 
       parsed_cards.each do |card|
-        expect(card[:type]).to eq('card')
-
-        card_attributes = card[:attributes]
-
-        expect(card_attributes).to have_key(:name)
-        expect(card_attributes).to have_key(:card_code)
-        expect(card_attributes).to have_key(:description)
-      end
-    end
-  end
-
-  describe 'GET /api/v1/cards/random' do
-    it 'returns a random card' do
-      get "/api/v1/cards/random"
-
-      parsed_card = JSON.parse(response.body, symbolize_names: true)[:data]
-
-      expect(response).to be_successful
-      expect(response.status).to eq(200)
-
-      expect(parsed_card[:type]).to eq('card')
-
-      card_attributes = parsed_card[:attributes]
-
-      expect(card_attributes).to have_key(:name)
-      expect(card_attributes).to have_key(:card_code)
-      expect(card_attributes).to have_key(:description)
-    end
-
-    it 'accepts a query parameter of limit that lets you return multiple random cards up to the limit' do
-      get "/api/v1/cards/random?limit=2"
-
-      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
-
-      expect(response).to be_successful
-      expect(response.status).to eq(200)
-
-      expect(parsed_cards.count).to eq(2)
-
-      parsed_cards.each do |card|
-        expect(card[:type]).to eq('card')
+        expect(card[:type]).to eq("card")
 
         card_attributes = card[:attributes]
 


### PR DESCRIPTION
# Description

Returns any amount of random cards.

## Context

- The request can be sent with or without a query parameter.
- If sent as /api/v1/cards/random it will return a single random card
- If sent as /api/v1/cards/random?limit=(n) it will return (n) amount of random cards
- To minimize the load on the database, an array of integers ranging from 1 to the total number of cards in the DB is generated. (n) amount of integers are then selected and the respective cards with those IDs are returned. By default, (n) is 1. 
- Also updates the seeded data with set9 cards.

Closes #26 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Created full request and model tests for all outcomes

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules