### PR TITLE
Feat/invalid search parameters handling

### DIFF
--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -30,10 +30,14 @@ class Api::V1::CardsController < ApplicationController
         params.delete(key)
       end
 
-      cards = Card.search(params)
-      hash = CardSerializer.new(cards)
+      if params != {}
+        cards = Card.search(params)
+        hash = CardSerializer.new(cards)
 
-      hash = JSON.parse(hash.to_json, symbolize_names: true)
+        hash = JSON.parse(hash.to_json, symbolize_names: true)
+      else
+        hash = { data: [] }
+      end
 
       hash[:error] = []
 

--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -24,17 +24,19 @@ class Api::V1::CardsController < ApplicationController
       hash[:error] = []
     else
       invalid = find_invalid_search_keys
-      params = format_search_params
+      valid_params = format_search_params
 
       invalid.each do |key|
-        params.delete(key)
+        valid_params.delete(key)
       end
 
-      if params != {}
-        cards = Card.search(params)
-        hash = CardSerializer.new(cards)
+      if valid_params != {}
+        cards = Card.search(valid_params)
 
-        hash = JSON.parse(hash.to_json, symbolize_names: true)
+        hash = JSON.parse(
+          CardSerializer.new(cards).to_json,
+          symbolize_names: true
+        )
       else
         hash = { data: [] }
       end

--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -20,6 +20,7 @@ class Api::V1::CardsController < ApplicationController
     if valid_search_params?
       cards = Card.search(format_search_params)
       hash = CardSerializer.new(cards)
+      hash = JSON.parse(hash.to_json, symbolize_names: true)
       hash[:error] = []
     else
       invalid = find_invalid_search_keys

--- a/spec/requests/api/v1/cards_request_spec.rb
+++ b/spec/requests/api/v1/cards_request_spec.rb
@@ -632,27 +632,41 @@ RSpec.describe Api::V1::CardsController, type: :request do
     it "returns an unsupported query error if an invalid filter is used" do
       get "/api/v1/cards/search?query=" + CGI.escape("drav invalid:axe")
 
-      expect(response).to_not be_successful
-      expect(response.status).to eq(400)
-      expect(response.body).to include("invalid is an invalid search query")
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:error]).to eq(["invalid is an invalid search parameter"])
     end
 
     it "returns an unsupported query error if multiple invalid filters are used" do
       get "/api/v1/cards/search?query=" + CGI.escape("drav invalid:axe invalid2:axe")
 
-      expect(response).to_not be_successful
-      expect(response.status).to eq(400)
-      expect(response.body).to include(
-        "[invalid, invalid2] are invalid search queries"
-      )
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:error]).to eq([
+        "invalid is an invalid search parameter",
+        "invalid2 is an invalid search parameter"
+      ])
     end
 
     it "returns an unsupported query error if an invalid filter is used with a valid filter" do
       get "/api/v1/cards/search?query=" + CGI.escape("drav invalid:axe description:axe")
 
-      expect(response).to_not be_successful
-      expect(response.status).to eq(400)
-      expect(response.body).to include("invalid is an invalid search query")
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:error]).to eq(["invalid is an invalid search parameter"])
+    end
+
+    it "ignores 'mode', 'attribute', and 'direction' parameters" do
+      get "/api/v1/cards/search?query=" + CGI.escape("#{@card.name} mode:image attribute:something direction:desc")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+      body = JSON.parse(response.body, symbolize_names: true)
+      expect(body[:error]).to eq([])
+      expect(body[:data].count > 0).to eq(true)
     end
   end
 end


### PR DESCRIPTION
# Description

Updates to the API spec

## Context

This changes the API endpoint `/api/v1/search` spec to always return an array of errors and array of data, i.e.
```js
// response =>
{
  data: [...],
  error: [...]
}
```
This is true even when one or both arrays are empty. It also ignores "mode", "attribute", and "direction" parameters that are included in the search query

Fixes #28 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Changed any spec files to conform to new standard, and wrote a test to validate that "mode", "attribute", and "direction" are ignored

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules