### PR TITLE
Add ability to search by attack, health, or cost

### DIFF
--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -150,9 +150,6 @@ class Api::V1::CardsController < ApplicationController
           value = value.delete('"').to_i
           attributes[key_symbol] = [:>=, value]
         end
-      elsif /:[<>=]?=?.*\b/.match?((attr[0]))
-        require "pry"
-        binding.pry
       elsif !attr[0].empty?
         attributes[:name] << attr[0].delete('"').strip
       end

--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -46,6 +46,10 @@ class Api::V1::CardsController < ApplicationController
       invalid.each do |key|
         hash[:error] << "#{key} is an invalid search parameter"
       end
+
+      if /\w+[<>=]=?/.match?(params[:query])
+        hash[:error] << "You must include a colon after the key, e.g. attack:<5"
+      end
     end
 
     render json: hash
@@ -202,6 +206,8 @@ class Api::V1::CardsController < ApplicationController
   end
 
   def valid_search_params?
+    return false if /\w+[<>=]=?/.match?(params[:query])
+
     format_search_params.all? do |param|
       key, = param.first
       permitted_search_criteria.include?(key)

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -11,6 +11,43 @@ class Card < ApplicationRecord
       )
     end
 
+    # This filters by cost, health, and attack, being either
+    # <, >, =, <=, or >= than the value in the query string
+    %i[cost health attack].each do |filter|
+      next unless filters[filter]
+
+      operator = filters[filter][0]
+      value = filters[filter][1]
+
+      case operator
+      when :<
+        cards = cards.where(
+          "#{filter} < ?",
+          value
+        )
+      when :>
+        cards = cards.where(
+          "#{filter} > ?",
+          value
+        )
+      when :==
+        cards = cards.where(
+          "#{filter} = ?",
+          value
+        )
+      when :<=
+        cards = cards.where(
+          "#{filter} <= ?",
+          value
+        )
+      when :>=
+        cards = cards.where(
+          "#{filter} >= ?",
+          value
+        )
+      end
+    end
+
     # This uses the ILIKE operator to search by
     # name, description, etc. in a case-insensitive manner
     %i[description rarity artist_name set

--- a/spec/requests/api/v1/cards_request_spec.rb
+++ b/spec/requests/api/v1/cards_request_spec.rb
@@ -674,148 +674,148 @@ RSpec.describe Api::V1::CardsController, type: :request do
     it "can search by attack, cost, and health" do
       create(:card, attack: 100, cost: 100, health: 100)
 
-      # # Search for cards by cost
+      # Search for cards by cost
 
-      # get "/api/v1/cards/search?query=" + CGI.escape("cost:=100")
+      get "/api/v1/cards/search?query=" + CGI.escape("cost:=100")
 
-      # expect(response).to be_successful
-      # expect(response.status).to eq(200)
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
 
-      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
 
-      # expect(parsed_cards).to be_an(Array)
-      # expect(parsed_cards.count).to eq(1)
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(1)
 
-      # get "/api/v1/cards/search?query=" + CGI.escape("cost:>99")
+      get "/api/v1/cards/search?query=" + CGI.escape("cost:>99")
 
-      # expect(response).to be_successful
-      # expect(response.status).to eq(200)
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
 
-      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
 
-      # expect(parsed_cards).to be_an(Array)
-      # expect(parsed_cards.count).to eq(1)
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(1)
 
-      # get "/api/v1/cards/search?query=" + CGI.escape("cost:<101")
+      get "/api/v1/cards/search?query=" + CGI.escape("cost:<101")
 
-      # expect(response).to be_successful
-      # expect(response.status).to eq(200)
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
 
-      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
 
-      # expect(parsed_cards).to be_an(Array)
-      # expect(parsed_cards.count).to eq(5)
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(5)
 
-      # get "/api/v1/cards/search?query=" + CGI.escape("cost:<=100")
+      get "/api/v1/cards/search?query=" + CGI.escape("cost:<=100")
 
-      # expect(response).to be_successful
-      # expect(response.status).to eq(200)
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
 
-      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
 
-      # expect(parsed_cards).to be_an(Array)
-      # expect(parsed_cards.count).to eq(5)
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(5)
 
-      # get "/api/v1/cards/search?query=" + CGI.escape("cost:>=100")
+      get "/api/v1/cards/search?query=" + CGI.escape("cost:>=100")
 
-      # expect(response).to be_successful
-      # expect(response.status).to eq(200)
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
 
-      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
 
-      # expect(parsed_cards).to be_an(Array)
-      # expect(parsed_cards.count).to eq(1)
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(1)
 
-      # get "/api/v1/cards/search?query=" + CGI.escape("cost:=101")
+      get "/api/v1/cards/search?query=" + CGI.escape("cost:=101")
 
-      # expect(response).to be_successful
-      # expect(response.status).to eq(200)
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
 
-      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
 
-      # expect(parsed_cards).to be_an(Array)
-      # expect(parsed_cards.count).to eq(0)
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(0)
 
-      # # Search for cards by attack
+      # Search for cards by attack
 
-      # get "/api/v1/cards/search?query=" + CGI.escape("attack:=100")
+      get "/api/v1/cards/search?query=" + CGI.escape("attack:=100")
 
-      # expect(response).to be_successful
-      # expect(response.status).to eq(200)
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
 
-      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
 
-      # expect(parsed_cards).to be_an(Array)
-      # expect(parsed_cards.count).to eq(1)
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(1)
 
-      # get "/api/v1/cards/search?query=" + CGI.escape("attack:>99")
+      get "/api/v1/cards/search?query=" + CGI.escape("attack:>99")
 
-      # expect(response).to be_successful
-      # expect(response.status).to eq(200)
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
 
-      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
 
-      # expect(parsed_cards).to be_an(Array)
-      # expect(parsed_cards.count).to eq(1)
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(1)
 
-      # get "/api/v1/cards/search?query=" + CGI.escape("attack:<101")
+      get "/api/v1/cards/search?query=" + CGI.escape("attack:<101")
 
-      # expect(response).to be_successful
-      # expect(response.status).to eq(200)
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
 
-      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
 
-      # expect(parsed_cards).to be_an(Array)
-      # expect(parsed_cards.count).to eq(5)
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(5)
 
-      # get "/api/v1/cards/search?query=" + CGI.escape("attack:<=100")
+      get "/api/v1/cards/search?query=" + CGI.escape("attack:<=100")
 
-      # expect(response).to be_successful
-      # expect(response.status).to eq(200)
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
 
-      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
 
-      # expect(parsed_cards).to be_an(Array)
-      # expect(parsed_cards.count).to eq(5)
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(5)
 
-      # get "/api/v1/cards/search?query=" + CGI.escape("attack:>=100")
+      get "/api/v1/cards/search?query=" + CGI.escape("attack:>=100")
 
-      # expect(response).to be_successful
-      # expect(response.status).to eq(200)
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
 
-      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
 
-      # expect(parsed_cards).to be_an(Array)
-      # expect(parsed_cards.count).to eq(1)
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(1)
 
-      # get "/api/v1/cards/search?query=" + CGI.escape("attack:=101")
+      get "/api/v1/cards/search?query=" + CGI.escape("attack:=101")
 
-      # expect(response).to be_successful
-      # expect(response.status).to eq(200)
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
 
-      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
 
-      # expect(parsed_cards).to be_an(Array)
-      # expect(parsed_cards.count).to eq(0)
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(0)
 
-      # # Search for cards by health
+      # Search for cards by health
 
-      # get "/api/v1/cards/search?query=" + CGI.escape("health:=100")
+      get "/api/v1/cards/search?query=" + CGI.escape("health:=100")
 
-      # expect(response).to be_successful
-      # expect(response.status).to eq(200)
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
 
-      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
 
-      # get "/api/v1/cards/search?query=" + CGI.escape("health:100")
+      get "/api/v1/cards/search?query=" + CGI.escape("health:100")
 
-      # expect(response).to be_successful
-      # expect(response.status).to eq(200)
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
 
-      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
 
-      # expect(parsed_cards).to be_an(Array)
-      # expect(parsed_cards.count).to eq(1)
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(1)
 
       get "/api/v1/cards/search?query=" + CGI.escape("health:>99")
 

--- a/spec/requests/api/v1/cards_request_spec.rb
+++ b/spec/requests/api/v1/cards_request_spec.rb
@@ -674,9 +674,150 @@ RSpec.describe Api::V1::CardsController, type: :request do
     it "can search by attack, cost, and health" do
       create(:card, attack: 100, cost: 100, health: 100)
 
-      # Search for cards by cost
+      # # Search for cards by cost
 
-      get "/api/v1/cards/search?query=" + CGI.escape("cost=100")
+      # get "/api/v1/cards/search?query=" + CGI.escape("cost:=100")
+
+      # expect(response).to be_successful
+      # expect(response.status).to eq(200)
+
+      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      # expect(parsed_cards).to be_an(Array)
+      # expect(parsed_cards.count).to eq(1)
+
+      # get "/api/v1/cards/search?query=" + CGI.escape("cost:>99")
+
+      # expect(response).to be_successful
+      # expect(response.status).to eq(200)
+
+      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      # expect(parsed_cards).to be_an(Array)
+      # expect(parsed_cards.count).to eq(1)
+
+      # get "/api/v1/cards/search?query=" + CGI.escape("cost:<101")
+
+      # expect(response).to be_successful
+      # expect(response.status).to eq(200)
+
+      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      # expect(parsed_cards).to be_an(Array)
+      # expect(parsed_cards.count).to eq(5)
+
+      # get "/api/v1/cards/search?query=" + CGI.escape("cost:<=100")
+
+      # expect(response).to be_successful
+      # expect(response.status).to eq(200)
+
+      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      # expect(parsed_cards).to be_an(Array)
+      # expect(parsed_cards.count).to eq(5)
+
+      # get "/api/v1/cards/search?query=" + CGI.escape("cost:>=100")
+
+      # expect(response).to be_successful
+      # expect(response.status).to eq(200)
+
+      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      # expect(parsed_cards).to be_an(Array)
+      # expect(parsed_cards.count).to eq(1)
+
+      # get "/api/v1/cards/search?query=" + CGI.escape("cost:=101")
+
+      # expect(response).to be_successful
+      # expect(response.status).to eq(200)
+
+      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      # expect(parsed_cards).to be_an(Array)
+      # expect(parsed_cards.count).to eq(0)
+
+      # # Search for cards by attack
+
+      # get "/api/v1/cards/search?query=" + CGI.escape("attack:=100")
+
+      # expect(response).to be_successful
+      # expect(response.status).to eq(200)
+
+      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      # expect(parsed_cards).to be_an(Array)
+      # expect(parsed_cards.count).to eq(1)
+
+      # get "/api/v1/cards/search?query=" + CGI.escape("attack:>99")
+
+      # expect(response).to be_successful
+      # expect(response.status).to eq(200)
+
+      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      # expect(parsed_cards).to be_an(Array)
+      # expect(parsed_cards.count).to eq(1)
+
+      # get "/api/v1/cards/search?query=" + CGI.escape("attack:<101")
+
+      # expect(response).to be_successful
+      # expect(response.status).to eq(200)
+
+      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      # expect(parsed_cards).to be_an(Array)
+      # expect(parsed_cards.count).to eq(5)
+
+      # get "/api/v1/cards/search?query=" + CGI.escape("attack:<=100")
+
+      # expect(response).to be_successful
+      # expect(response.status).to eq(200)
+
+      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      # expect(parsed_cards).to be_an(Array)
+      # expect(parsed_cards.count).to eq(5)
+
+      # get "/api/v1/cards/search?query=" + CGI.escape("attack:>=100")
+
+      # expect(response).to be_successful
+      # expect(response.status).to eq(200)
+
+      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      # expect(parsed_cards).to be_an(Array)
+      # expect(parsed_cards.count).to eq(1)
+
+      # get "/api/v1/cards/search?query=" + CGI.escape("attack:=101")
+
+      # expect(response).to be_successful
+      # expect(response.status).to eq(200)
+
+      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      # expect(parsed_cards).to be_an(Array)
+      # expect(parsed_cards.count).to eq(0)
+
+      # # Search for cards by health
+
+      # get "/api/v1/cards/search?query=" + CGI.escape("health:=100")
+
+      # expect(response).to be_successful
+      # expect(response.status).to eq(200)
+
+      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      # get "/api/v1/cards/search?query=" + CGI.escape("health:100")
+
+      # expect(response).to be_successful
+      # expect(response.status).to eq(200)
+
+      # parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      # expect(parsed_cards).to be_an(Array)
+      # expect(parsed_cards.count).to eq(1)
+
+      get "/api/v1/cards/search?query=" + CGI.escape("health:>99")
 
       expect(response).to be_successful
       expect(response.status).to eq(200)
@@ -686,17 +827,7 @@ RSpec.describe Api::V1::CardsController, type: :request do
       expect(parsed_cards).to be_an(Array)
       expect(parsed_cards.count).to eq(1)
 
-      get "/api/v1/cards/search?query=" + CGI.escape("cost>99")
-
-      expect(response).to be_successful
-      expect(response.status).to eq(200)
-
-      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
-
-      expect(parsed_cards).to be_an(Array)
-      expect(parsed_cards.count).to eq(1)
-
-      get "/api/v1/cards/search?query=" + CGI.escape("cost<101")
+      get "/api/v1/cards/search?query=" + CGI.escape("health:<101")
 
       expect(response).to be_successful
       expect(response.status).to eq(200)
@@ -706,7 +837,7 @@ RSpec.describe Api::V1::CardsController, type: :request do
       expect(parsed_cards).to be_an(Array)
       expect(parsed_cards.count).to eq(5)
 
-      get "/api/v1/cards/search?query=" + CGI.escape("cost<=100")
+      get "/api/v1/cards/search?query=" + CGI.escape("health:<=100")
 
       expect(response).to be_successful
       expect(response.status).to eq(200)
@@ -716,7 +847,7 @@ RSpec.describe Api::V1::CardsController, type: :request do
       expect(parsed_cards).to be_an(Array)
       expect(parsed_cards.count).to eq(5)
 
-      get "/api/v1/cards/search?query=" + CGI.escape("cost>=100")
+      get "/api/v1/cards/search?query=" + CGI.escape("health:>=100")
 
       expect(response).to be_successful
       expect(response.status).to eq(200)
@@ -726,131 +857,7 @@ RSpec.describe Api::V1::CardsController, type: :request do
       expect(parsed_cards).to be_an(Array)
       expect(parsed_cards.count).to eq(1)
 
-      get "/api/v1/cards/search?query=" + CGI.escape("cost=101")
-
-      expect(response).to be_successful
-      expect(response.status).to eq(200)
-
-      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
-
-      expect(parsed_cards).to be_an(Array)
-      expect(parsed_cards.count).to eq(0)
-
-      # Search for cards by attack
-
-      get "/api/v1/cards/search?query=" + CGI.escape("attack=100")
-
-      expect(response).to be_successful
-      expect(response.status).to eq(200)
-
-      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
-
-      expect(parsed_cards).to be_an(Array)
-      expect(parsed_cards.count).to eq(1)
-
-      get "/api/v1/cards/search?query=" + CGI.escape("attack>99")
-
-      expect(response).to be_successful
-      expect(response.status).to eq(200)
-
-      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
-
-      expect(parsed_cards).to be_an(Array)
-      expect(parsed_cards.count).to eq(1)
-
-      get "/api/v1/cards/search?query=" + CGI.escape("attack<101")
-
-      expect(response).to be_successful
-      expect(response.status).to eq(200)
-
-      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
-
-      expect(parsed_cards).to be_an(Array)
-      expect(parsed_cards.count).to eq(5)
-
-      get "/api/v1/cards/search?query=" + CGI.escape("attack<=100")
-
-      expect(response).to be_successful
-      expect(response.status).to eq(200)
-
-      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
-
-      expect(parsed_cards).to be_an(Array)
-      expect(parsed_cards.count).to eq(5)
-
-      get "/api/v1/cards/search?query=" + CGI.escape("attack>=100")
-
-      expect(response).to be_successful
-      expect(response.status).to eq(200)
-
-      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
-
-      expect(parsed_cards).to be_an(Array)
-      expect(parsed_cards.count).to eq(1)
-
-      get "/api/v1/cards/search?query=" + CGI.escape("attack=101")
-
-      expect(response).to be_successful
-      expect(response.status).to eq(200)
-
-      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
-
-      expect(parsed_cards).to be_an(Array)
-      expect(parsed_cards.count).to eq(0)
-
-      # Search for cards by health
-
-      get "/api/v1/cards/search?query=" + CGI.escape("health=100")
-
-      expect(response).to be_successful
-      expect(response.status).to eq(200)
-
-      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
-
-      expect(parsed_cards).to be_an(Array)
-      expect(parsed_cards.count).to eq(1)
-
-      get "/api/v1/cards/search?query=" + CGI.escape("health>99")
-
-      expect(response).to be_successful
-      expect(response.status).to eq(200)
-
-      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
-
-      expect(parsed_cards).to be_an(Array)
-      expect(parsed_cards.count).to eq(1)
-
-      get "/api/v1/cards/search?query=" + CGI.escape("health<101")
-
-      expect(response).to be_successful
-      expect(response.status).to eq(200)
-
-      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
-
-      expect(parsed_cards).to be_an(Array)
-      expect(parsed_cards.count).to eq(5)
-
-      get "/api/v1/cards/search?query=" + CGI.escape("health<=100")
-
-      expect(response).to be_successful
-      expect(response.status).to eq(200)
-
-      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
-
-      expect(parsed_cards).to be_an(Array)
-      expect(parsed_cards.count).to eq(5)
-
-      get "/api/v1/cards/search?query=" + CGI.escape("health>=100")
-
-      expect(response).to be_successful
-      expect(response.status).to eq(200)
-
-      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
-
-      expect(parsed_cards).to be_an(Array)
-      expect(parsed_cards.count).to eq(1)
-
-      get "/api/v1/cards/search?query=" + CGI.escape("health=101")
+      get "/api/v1/cards/search?query=" + CGI.escape("health:=101")
 
       expect(response).to be_successful
       expect(response.status).to eq(200)
@@ -862,7 +869,7 @@ RSpec.describe Api::V1::CardsController, type: :request do
     end
 
     it "does not break when given unexpected characters" do
-      get "/api/v1/cards/search?query=" + CGI.escape("attack=a")
+      get "/api/v1/cards/search?query=" + CGI.escape("attack:a")
 
       expect(response).to be_successful
       expect(response.status).to eq(200)
@@ -875,7 +882,7 @@ RSpec.describe Api::V1::CardsController, type: :request do
       expect(parsed_cards[:data]).to be_an(Array)
       expect(parsed_cards[:data].count).to eq(0)
 
-      get "/api/v1/cards/search?query=" + CGI.escape('cost="a"')
+      get "/api/v1/cards/search?query=" + CGI.escape('cost:="a"')
 
       expect(response).to be_successful
       expect(response.status).to eq(200)

--- a/spec/requests/api/v1/cards_request_spec.rb
+++ b/spec/requests/api/v1/cards_request_spec.rb
@@ -164,9 +164,9 @@ RSpec.describe Api::V1::CardsController, type: :request do
         set: "Set Name",
         flavor_text: "Flavor Text",
         card_type: "Unit",
-        attack: 1,
-        cost: 2,
-        health: 3
+        attack: 6,
+        cost: 6,
+        health: 6
       )
 
       # Search by description
@@ -669,6 +669,221 @@ RSpec.describe Api::V1::CardsController, type: :request do
       body = JSON.parse(response.body, symbolize_names: true)
       expect(body[:error]).to eq([])
       expect(body[:data].count > 0).to eq(true)
+    end
+
+    it "can search by attack, cost, and health" do
+      create(:card, attack: 100, cost: 100, health: 100)
+
+      # Search for cards by cost
+
+      get "/api/v1/cards/search?query=" + CGI.escape("cost=100")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(1)
+
+      get "/api/v1/cards/search?query=" + CGI.escape("cost>99")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(1)
+
+      get "/api/v1/cards/search?query=" + CGI.escape("cost<101")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(5)
+
+      get "/api/v1/cards/search?query=" + CGI.escape("cost<=100")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(5)
+
+      get "/api/v1/cards/search?query=" + CGI.escape("cost>=100")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(1)
+
+      get "/api/v1/cards/search?query=" + CGI.escape("cost=101")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(0)
+
+      # Search for cards by attack
+
+      get "/api/v1/cards/search?query=" + CGI.escape("attack=100")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(1)
+
+      get "/api/v1/cards/search?query=" + CGI.escape("attack>99")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(1)
+
+      get "/api/v1/cards/search?query=" + CGI.escape("attack<101")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(5)
+
+      get "/api/v1/cards/search?query=" + CGI.escape("attack<=100")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(5)
+
+      get "/api/v1/cards/search?query=" + CGI.escape("attack>=100")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(1)
+
+      get "/api/v1/cards/search?query=" + CGI.escape("attack=101")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(0)
+
+      # Search for cards by health
+
+      get "/api/v1/cards/search?query=" + CGI.escape("health=100")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(1)
+
+      get "/api/v1/cards/search?query=" + CGI.escape("health>99")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(1)
+
+      get "/api/v1/cards/search?query=" + CGI.escape("health<101")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(5)
+
+      get "/api/v1/cards/search?query=" + CGI.escape("health<=100")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(5)
+
+      get "/api/v1/cards/search?query=" + CGI.escape("health>=100")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(1)
+
+      get "/api/v1/cards/search?query=" + CGI.escape("health=101")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(0)
+    end
+
+    it "does not break when given unexpected characters" do
+      get "/api/v1/cards/search?query=" + CGI.escape("attack=a")
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      expect(parsed_cards[:data]).to be_an(Array)
+      expect(parsed_cards[:data].count).to eq(0)
+
+      get "/api/v1/cards/search?query=" + CGI.escape('cost="a"')
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)
+
+      expect(parsed_cards[:data]).to be_an(Array)
+      expect(parsed_cards[:data].count).to eq(0)
     end
   end
 


### PR DESCRIPTION
# Description

This adds the ability to search by attack, health, or cost

## Context

You can now use =, <, >, <= and >= to search for cards based on cost, attack, or health. E.g.,
```
axe attack>1 cost<=3 description:"an axe"
```

Fixes #24 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Happy path testing - expected results
- [x] Sad path testing - special characters and unexpected inputs do not break the search function

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules