### PR TITLE
Feat/multiple queries with or

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,398 @@ Response: `status: 200`
     ]
 }
 ```
+
+Multiple Queries
+- Separating multiple full queries with "OR" will return all cards from each query combined
+    - Example: `GET /api/v1/cards/search?query=name:draven attack:>3 OR name:darius attack:>7`
+    
+```JSON
+{
+    "data": [
+        {
+            "id": "71",
+            "type": "card",
+            "attributes": {
+                "name": "Draven",
+                "card_code": "01NX020T3",
+                "description": "When I'm summoned or <link=vocab.Strike><style=Vocab>strike</style></link>: Create 2 <link=card.create><style=AssociatedCard>Spinning Axes</style></link> in hand.",
+                "description_raw": "When I'm summoned or strike: Create 2 Spinning Axes in hand.",
+                "levelup_description": "",
+                "levelup_description_raw": "",
+                "flavor_text": "\"WHAT'S MY NAME?\"",
+                "artist_name": "SIXMOREVODKA",
+                "attack": 4,
+                "cost": 3,
+                "health": 4,
+                "spell_speed": "",
+                "rarity": "None",
+                "supertype": "Champion",
+                "card_type": "Unit",
+                "collectible": false,
+                "set": "Set1",
+                "associated_card_refs": [
+                    "01NX020T2",
+                    "01NX020",
+                    "01NX020T1"
+                ],
+                "regions": [
+                    "Noxus"
+                ],
+                "region_refs": [
+                    "Noxus"
+                ],
+                "keywords": [
+                    "Quick Attack",
+                    "Overwhelm"
+                ],
+                "keyword_refs": [
+                    "QuickStrike",
+                    "Overwhelm"
+                ],
+                "formats": [
+                    "Eternal",
+                    "Standard"
+                ],
+                "format_refs": [
+                    "client_Formats_Eternal_name",
+                    "client_Formats_Standard_name"
+                ],
+                "assets": [
+                    {
+                        "game_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01NX020T3.png",
+                        "full_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01NX020T3-full.png"
+                    }
+                ],
+                "associated_cards": [
+                    {
+                        "id": 72,
+                        "name": "Draven's Whirling Death",
+                        "card_code": "01NX020T2",
+                        "description": "A battling ally <link=vocab.Strike><style=Vocab>strikes</style></link> a battling enemy.\r\nCreate a <link=card.level1><style=AssociatedCard>Draven</style></link> in your deck.",
+                        "description_raw": "A battling ally strikes a battling enemy.\r\nCreate a Draven in your deck.",
+                        "levelup_description": "",
+                        "levelup_description_raw": "",
+                        "flavor_text": "\"I have the best job.\" - Draven",
+                        "artist_name": "Rafael Zanchetin",
+                        "attack": 0,
+                        "cost": 3,
+                        "health": 0,
+                        "spell_speed": "Fast",
+                        "rarity": "None",
+                        "supertype": "Champion",
+                        "card_type": "Spell",
+                        "collectible": false,
+                        "set": "Set1",
+                        "associated_card_refs": [
+                            "01NX020T3",
+                            "01NX020"
+                        ],
+                        "regions": [
+                            "Noxus"
+                        ],
+                        "region_refs": [
+                            "Noxus"
+                        ],
+                        "keywords": [
+                            "Fast"
+                        ],
+                        "keyword_refs": [
+                            "Fast"
+                        ],
+                        "formats": [
+                            "Eternal",
+                            "Standard"
+                        ],
+                        "format_refs": [
+                            "client_Formats_Eternal_name",
+                            "client_Formats_Standard_name"
+                        ],
+                        "assets": [
+                            {
+                                "game_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01NX020T2.png",
+                                "full_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01NX020T2-full.png"
+                            }
+                        ],
+                        "created_at": "2024-07-30T16:17:29.438Z",
+                        "updated_at": "2024-07-30T16:17:29.438Z",
+                        "associated_cards": []
+                    },
+                    {
+                        "id": 70,
+                        "name": "Draven",
+                        "card_code": "01NX020",
+                        "description": "When I'm summoned or <link=vocab.Strike><style=Vocab>strike</style></link>: Create a <link=card.create><style=AssociatedCard>Spinning Axe</style></link> in hand.",
+                        "description_raw": "When I'm summoned or strike: Create a Spinning Axe in hand.",
+                        "levelup_description": "I've <link=vocab.Strike><style=Vocab>struck</style></link> with 2+ total <link=card.create><style=AssociatedCard>Spinning Axes</style></link>.<style=Variable></style>",
+                        "levelup_description_raw": "I've struck with 2+ total Spinning Axes.",
+                        "flavor_text": "\"You want an autograph? Get in line, pal.\"",
+                        "artist_name": "SIXMOREVODKA",
+                        "attack": 3,
+                        "cost": 3,
+                        "health": 3,
+                        "spell_speed": "",
+                        "rarity": "Champion",
+                        "supertype": "Champion",
+                        "card_type": "Unit",
+                        "collectible": true,
+                        "set": "Set1",
+                        "associated_card_refs": [
+                            "01NX020T1",
+                            "01NX020T3",
+                            "01NX020T2"
+                        ],
+                        "regions": [
+                            "Noxus"
+                        ],
+                        "region_refs": [
+                            "Noxus"
+                        ],
+                        "keywords": [
+                            "Quick Attack"
+                        ],
+                        "keyword_refs": [
+                            "QuickStrike"
+                        ],
+                        "formats": [
+                            "Commons Only",
+                            "Eternal"
+                        ],
+                        "format_refs": [
+                            "client_Formats_CommonsOnly_name",
+                            "client_Formats_Eternal_name"
+                        ],
+                        "assets": [
+                            {
+                                "game_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01NX020.png",
+                                "full_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01NX020-full.png"
+                            }
+                        ],
+                        "created_at": "2024-07-30T16:17:29.434Z",
+                        "updated_at": "2024-07-30T16:17:29.434Z",
+                        "associated_cards": []
+                    },
+                    {
+                        "id": 73,
+                        "name": "Spinning Axe",
+                        "card_code": "01NX020T1",
+                        "description": "To play, discard 1.\r\nGive an ally +1|+0 this round.",
+                        "description_raw": "To play, discard 1.\r\nGive an ally +1|+0 this round.",
+                        "levelup_description": "",
+                        "levelup_description_raw": "",
+                        "flavor_text": "\"Yeah, his brother'd win one-on-one, but you see those axes spiraling... it's art, it is. Art.\" - Arena regular",
+                        "artist_name": "SIXMOREVODKA",
+                        "attack": 0,
+                        "cost": 0,
+                        "health": 0,
+                        "spell_speed": "Burst",
+                        "rarity": "None",
+                        "supertype": "",
+                        "card_type": "Spell",
+                        "collectible": false,
+                        "set": "Set1",
+                        "associated_card_refs": [
+                            "01NX020"
+                        ],
+                        "regions": [
+                            "Noxus"
+                        ],
+                        "region_refs": [
+                            "Noxus"
+                        ],
+                        "keywords": [
+                            "Burst"
+                        ],
+                        "keyword_refs": [
+                            "Burst"
+                        ],
+                        "formats": [
+                            "Eternal",
+                            "Standard"
+                        ],
+                        "format_refs": [
+                            "client_Formats_Eternal_name",
+                            "client_Formats_Standard_name"
+                        ],
+                        "assets": [
+                            {
+                                "game_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01NX020T1.png",
+                                "full_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01NX020T1-full.png"
+                            }
+                        ],
+                        "created_at": "2024-07-30T16:17:29.440Z",
+                        "updated_at": "2024-07-30T16:17:29.440Z",
+                        "associated_cards": []
+                    }
+                ]
+            }
+        },
+        {
+            "id": "88",
+            "type": "card",
+            "attributes": {
+                "name": "Darius",
+                "card_code": "01NX038T2",
+                "description": "",
+                "description_raw": "",
+                "levelup_description": "",
+                "levelup_description_raw": "",
+                "flavor_text": "\"Stand in our way and I'll cut you down myself!\"",
+                "artist_name": "SIXMOREVODKA",
+                "attack": 10,
+                "cost": 6,
+                "health": 7,
+                "spell_speed": "",
+                "rarity": "None",
+                "supertype": "Champion",
+                "card_type": "Unit",
+                "collectible": false,
+                "set": "Set1",
+                "associated_card_refs": [
+                    "01NX038T1",
+                    "01NX038"
+                ],
+                "regions": [
+                    "Noxus"
+                ],
+                "region_refs": [
+                    "Noxus"
+                ],
+                "keywords": [
+                    "Overwhelm"
+                ],
+                "keyword_refs": [
+                    "Overwhelm"
+                ],
+                "formats": [
+                    "Eternal",
+                    "Standard"
+                ],
+                "format_refs": [
+                    "client_Formats_Eternal_name",
+                    "client_Formats_Standard_name"
+                ],
+                "assets": [
+                    {
+                        "game_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01NX038T2.png",
+                        "full_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01NX038T2-full.png"
+                    }
+                ],
+                "associated_cards": [
+                    {
+                        "id": 89,
+                        "name": "Darius' Decimate",
+                        "card_code": "01NX038T1",
+                        "description": "Deal 4 to the enemy Nexus.\r\nCreate a <link=card.level1><style=AssociatedCard>Darius</style></link> in your deck.",
+                        "description_raw": "Deal 4 to the enemy Nexus.\r\nCreate a Darius in your deck.",
+                        "levelup_description": "",
+                        "levelup_description_raw": "",
+                        "flavor_text": "\"Sometimes, it takes tactical genius to break a fortress. Sometimes, you just have to hit it harder.\" - Darius",
+                        "artist_name": "Max Grecke",
+                        "attack": 0,
+                        "cost": 6,
+                        "health": 0,
+                        "spell_speed": "Slow",
+                        "rarity": "None",
+                        "supertype": "Champion",
+                        "card_type": "Spell",
+                        "collectible": false,
+                        "set": "Set1",
+                        "associated_card_refs": [
+                            "01NX038T2",
+                            "01NX038"
+                        ],
+                        "regions": [
+                            "Noxus"
+                        ],
+                        "region_refs": [
+                            "Noxus"
+                        ],
+                        "keywords": [
+                            "Slow"
+                        ],
+                        "keyword_refs": [
+                            "Slow"
+                        ],
+                        "formats": [
+                            "Eternal",
+                            "Standard"
+                        ],
+                        "format_refs": [
+                            "client_Formats_Eternal_name",
+                            "client_Formats_Standard_name"
+                        ],
+                        "assets": [
+                            {
+                                "game_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01NX038T1.png",
+                                "full_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01NX038T1-full.png"
+                            }
+                        ],
+                        "created_at": "2024-07-30T16:17:29.483Z",
+                        "updated_at": "2024-07-30T16:17:29.483Z",
+                        "associated_cards": []
+                    },
+                    {
+                        "id": 81,
+                        "name": "Darius",
+                        "card_code": "01NX038",
+                        "description": "",
+                        "description_raw": "",
+                        "levelup_description": "I see the enemy Nexus has half of its starting Health or less.<br><style=Variable></style>",
+                        "levelup_description_raw": "I see the enemy Nexus has half of its starting Health or less.",
+                        "flavor_text": "\"An iron will and a titan's strength. There is no finer general to lead the Trifarian Legion.\" - Swain\n",
+                        "artist_name": "SIXMOREVODKA",
+                        "attack": 6,
+                        "cost": 6,
+                        "health": 6,
+                        "spell_speed": "",
+                        "rarity": "Champion",
+                        "supertype": "Champion",
+                        "card_type": "Unit",
+                        "collectible": true,
+                        "set": "Set1",
+                        "associated_card_refs": [
+                            "01NX038T2",
+                            "01NX038T1"
+                        ],
+                        "regions": [
+                            "Noxus"
+                        ],
+                        "region_refs": [
+                            "Noxus"
+                        ],
+                        "keywords": [
+                            "Overwhelm"
+                        ],
+                        "keyword_refs": [
+                            "Overwhelm"
+                        ],
+                        "formats": [
+                            "Commons Only",
+                            "Eternal"
+                        ],
+                        "format_refs": [
+                            "client_Formats_CommonsOnly_name",
+                            "client_Formats_Eternal_name"
+                        ],
+                        "assets": [
+                            {
+                                "game_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01NX038.png",
+                                "full_absolute_path": "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01NX038-full.png"
+                            }
+                        ],
+                        "created_at": "2024-07-30T16:17:29.464Z",
+                        "updated_at": "2024-07-30T16:17:29.464Z",
+                        "associated_cards": []
+                    }
+                ]
+            }
+        }
+    ],
+    "error": []
+}
+```
+
+
 </details>
 
 <details>

--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -112,7 +112,8 @@ class Api::V1::CardsController < ApplicationController
 
   def reassign_keys(attributes)
     [
-      %i[d description],
+      %i[d description_raw],
+      %i[description description_raw],
       %i[t card_type],
       %i[r rarity],
       %i[type card_type],
@@ -139,7 +140,7 @@ class Api::V1::CardsController < ApplicationController
   end
 
   def permitted_search_criteria
-    %i[name description card_type rarity regions keywords formats artist_name
+    %i[name description_raw card_type rarity regions keywords formats artist_name
        set flavor_text]
   end
 end

--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -24,14 +24,16 @@ class Api::V1::CardsController < ApplicationController
       hash[:error] = []
     else
       invalid = find_invalid_search_keys
-      valid_params = format_search_params
+      queries = format_search_params
 
       invalid.each do |key|
-        valid_params.delete(key)
+        queries.each do |params|
+          params.delete(key)
+        end
       end
 
-      if valid_params != {}
-        cards = Card.search(valid_params)
+      if queries.all? { |params| params != {} }
+        cards = Card.search(queries)
 
         hash = JSON.parse(
           CardSerializer.new(cards).to_json,
@@ -209,14 +211,15 @@ class Api::V1::CardsController < ApplicationController
   end
 
   def valid_search_params?
-    format_search_params.all? do |param|
-      key, = param.first
-      permitted_search_criteria.include?(key)
+    format_search_params.all? do |params|
+      params.all? do |key, value|
+        permitted_search_criteria.include?(key)
+      end
     end
   end
 
   def permitted_search_criteria
-    %i[name description card_type rarity regions keywords formats artist_name
-       set flavor_text]
+    %i[name description_raw card_type rarity regions keywords formats artist_name
+       set flavor_text cost attack health]
   end
 end

--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -53,6 +53,7 @@ class Api::V1::CardsController < ApplicationController
         hash[:error] << "You must include a colon after the key, e.g. attack:<5"
       end
     end
+    hash[:error].uniq!
 
     render json: hash
   end

--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -54,18 +54,6 @@ class Api::V1::CardsController < ApplicationController
       )
     end
 
-    attributes_from_queries = attributes_from_queries.map do |query|
-      query.reduce([]) do |acc, attr|
-        acc << attr unless attr[0].nil?
-      end
-    end
-
-    attributes_from_queries.map! do |query|
-      query.map!(&:uniq!)
-    end
-    # This hash will store the search parameters
-    # Name is initially an empty string because we will
-    # use string concatenation to build the name attribute
     queries = []
     # This loop iterates over the array of arrays
     # and assigns the key-value pairs to the attributes hash.
@@ -102,7 +90,7 @@ class Api::V1::CardsController < ApplicationController
     # This removes the :name key if it is an empty string
     # Otherwise, it deletes any trailing whitespace
     queries.each do |attributes|
-      attributes.delete(:name) if attributes[:name] == []
+      attributes.delete(:name) if attributes[:name].empty?
       reassign_keys(attributes)
     end
 

--- a/app/controllers/api/v1/cards_controller.rb
+++ b/app/controllers/api/v1/cards_controller.rb
@@ -38,6 +38,8 @@ class Api::V1::CardsController < ApplicationController
   private
 
   def format_search_params
+    separated_queries = params[:query].split(/ or | OR | oR | Or /)
+
     # This regular expression splits the query string
     # into an array of arrays. Each sub-array contains
     # the key-value pair or a single word.
@@ -46,23 +48,25 @@ class Api::V1::CardsController < ApplicationController
     #   ['description:"a description here"'],
     #   ["draven"]
     # ]
-    attributes_from_query = params[:query].scan(
-      /((\w+:".*?"|\w+:\w+)?(\w+:".*?"|\w+:\w+)|\w+)/
-    )
-
-    attributes_from_query = attributes_from_query.reduce([]) do |acc, attr|
-      acc << attr unless attr[0].nil?
+    attributes_from_queries = separated_queries.map do |query|
+      query.scan(
+        /((\w+:".*?"|\w+:\w+)?(\w+:".*?"|\w+:\w+)|\w+)/
+      )
     end
 
-    attributes_from_query.map!(&:uniq!)
+    attributes_from_queries = attributes_from_queries.map do |query|
+      query.reduce([]) do |acc, attr|
+        acc << attr unless attr[0].nil?
+      end
+    end
 
+    attributes_from_queries.map! do |query|
+      query.map!(&:uniq!)
+    end
     # This hash will store the search parameters
     # Name is initially an empty string because we will
     # use string concatenation to build the name attribute
-    attributes = {
-      name: []
-    }
-
+    queries = []
     # This loop iterates over the array of arrays
     # and assigns the key-value pairs to the attributes hash.
     # If the key is empty, it appends the value to the name attribute.
@@ -72,35 +76,46 @@ class Api::V1::CardsController < ApplicationController
     #   region: "Ionia",
     #   description: "a description here"
     #  }
-    attributes_from_query.each do |attr|
-      if attr[0].include?(":")
-        key, value = attr[0].split(":")
-        key_symbol = key.delete('"').to_sym
+    attributes_from_queries.each_with_index do |query, index|
+      attributes = {
+        name: []
+      }
+      query.each do |attr|
+        if attr[0].include?(":")
 
-        if attributes[key_symbol]
-          attributes[key_symbol] << value.delete('"').strip
-        else
-          attributes[key_symbol] = [value.delete('"').strip]
+          key, value = attr[0].split(":")
+          key_symbol = key.delete('"').to_sym
+
+          if attributes[key_symbol]
+            attributes[key_symbol] << value.delete('"').strip
+          else
+            attributes[key_symbol] = [value.delete('"').strip]
+          end
+        elsif !attr[0].empty?
+          attributes[:name] << attr[0].delete('"').strip
         end
-      elsif !attr[0].empty?
-        attributes[:name] << attr[0].delete('"').strip
       end
+
+      queries[index] = attributes
     end
 
     # This removes the :name key if it is an empty string
     # Otherwise, it deletes any trailing whitespace
-    attributes.delete(:name) if attributes[:name] == []
+    queries.each do |attributes|
+      attributes.delete(:name) if attributes[:name] == []
+      reassign_keys(attributes)
+    end
 
-    reassign_keys(attributes)
-
-    attributes
+    queries
   end
 
   def find_invalid_search_keys
     invalid_keys = []
-    format_search_params.each do |param|
-      key, = param.first
-      invalid_keys << key unless permitted_search_criteria.include?(key)
+    format_search_params.each do |query|
+      query.each do |param|
+        key, = param.first
+        invalid_keys << key unless permitted_search_criteria.include?(key)
+      end
     end
     invalid_text = invalid_keys.join(", ")
     if invalid_keys.length > 1
@@ -133,9 +148,11 @@ class Api::V1::CardsController < ApplicationController
   end
 
   def valid_search_params?
-    format_search_params.all? do |param|
-      key, = param.first
-      permitted_search_criteria.include?(key)
+    format_search_params.all? do |query|
+      query.all? do |param|
+        key, = param.first
+        permitted_search_criteria.include?(key)
+      end
     end
   end
 

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -12,7 +12,7 @@ class Card < ApplicationRecord
     # end
     # This uses the ILIKE operator to search by
     # name, description, etc. in a case-insensitive manner
-    %i[name description rarity artist_name set
+    %i[name description_raw rarity artist_name set
        flavor_text card_type].each do |filter|
       next unless filters[filter]
 

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -10,12 +10,10 @@ class Card < ApplicationRecord
       temp_cards[index] = cards
     end
 
-
-    # This uses the ILIKE operator to search by
-    # name, description, etc. in a case-insensitive manner
-    %i[name description_raw rarity artist_name set
-       flavor_text card_type].each do |filter|
-      queries.each_with_index do |filters, index|
+    queries.each_with_index do |filters, index|
+      # This uses the ILIKE operator to search by
+      # name, description, etc. in a case-insensitive manner
+      %i[name description_raw rarity artist_name set flavor_text card_type].each do |filter|
         next unless filters[filter]
 
         filters[filter]&.each do |value|
@@ -25,14 +23,12 @@ class Card < ApplicationRecord
           )
         end
       end
-    end
 
-    # This uses the && operator to search by region, format, and keyword
-    # It searches the string array columns for any of the values
-    # contained within the query string, e.g. "Demacia, Ionia" searches
-    # for cards that are in either Demacia or Ionia, or both.
-    %i[regions formats keywords].each do |filter|
-      queries.each_with_index do |filters, index|
+      # This uses the && operator to search by region, format, and keyword
+      # It searches the string array columns for any of the values
+      # contained within the query string, e.g. "Demacia, Ionia" searches
+      # for cards that are in either Demacia or Ionia, or both.
+      %i[regions formats keywords].each do |filter|
         next unless filters[filter]
 
         # changes "demacia, ionia" to ["Demacia", "Ionia"]
@@ -68,8 +64,6 @@ class Card < ApplicationRecord
       end
     end
 
-    # combined_sql = temp_cards.map(&:to_sql).join(' UNION ')
-    # final_cards = Card.find_by_sql(combined_sql)
     temp_cards.reduce { |combined, results| combined.or(results) }
   end
 

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -4,16 +4,15 @@ class Card < ApplicationRecord
 
     # This searches for cards by name iteratively
     # for each name in the query string
-    filters[:name]&.each do |name|
-      cards = cards.where(
-        "name ILIKE ?",
-        "%#{name}%"
-      )
-    end
-
+    # filters[:name]&.each do |name|
+    #   cards = cards.where(
+    #     "name ILIKE ?",
+    #     "%#{name}%"
+    #   )
+    # end
     # This uses the ILIKE operator to search by
     # name, description, etc. in a case-insensitive manner
-    %i[description rarity artist_name set
+    %i[name description rarity artist_name set
        flavor_text card_type].each do |filter|
       next unless filters[filter]
 

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -11,46 +11,47 @@ class Card < ApplicationRecord
     end
 
     queries.each_with_index do |filters, index|
-    # This filters by cost, health, and attack, being either
-    # <, >, =, <=, or >= than the value in the query string
-    %i[cost health attack].each do |filter|
-      next unless filters[filter]
+      # This filters by cost, health, and attack, being either
+      # <, >, =, <=, or >= than the value in the query string
+      %i[cost health attack].each do |filter|
+        next unless filters[filter]
 
-      operator = filters[filter][0]
-      value = filters[filter][1]
+        operator = filters[filter][0]
+        value = filters[filter][1]
 
-      case operator
-      when :<
-        temp_cards[index] = temp_cards[index].where(
-          "#{filter} < ?",
-          value
-        )
-      when :>
-        temp_cards[index] = temp_cards[index].where(
-          "#{filter} > ?",
-          value
-        )
-      when :==
-        temp_cards[index] = temp_cards[index].where(
-          "#{filter} = ?",
-          value
-        )
-      when :<=
-        temp_cards[index] = temp_cards[index].where(
-          "#{filter} <= ?",
-          value
-        )
-      when :>=
-        temp_cards[index] = temp_cards[index].where(
-          "#{filter} >= ?",
-          value
-        )
+        case operator
+        when :<
+          temp_cards[index] = temp_cards[index].where(
+            "#{filter} < ?",
+            value
+          )
+        when :>
+          temp_cards[index] = temp_cards[index].where(
+            "#{filter} > ?",
+            value
+          )
+        when :==
+          temp_cards[index] = temp_cards[index].where(
+            "#{filter} = ?",
+            value
+          )
+        when :<=
+          temp_cards[index] = temp_cards[index].where(
+            "#{filter} <= ?",
+            value
+          )
+        when :>=
+          temp_cards[index] = temp_cards[index].where(
+            "#{filter} >= ?",
+            value
+          )
+        end
       end
-    end
 
       # This uses the ILIKE operator to search by
       # name, description, etc. in a case-insensitive manner
-      %i[name description_raw rarity artist_name set flavor_text card_type].each do |filter|
+      %i[name description_raw rarity artist_name set flavor_text
+         card_type].each do |filter|
         next unless filters[filter]
 
         filters[filter]&.each do |value|

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -21,27 +21,27 @@ class Card < ApplicationRecord
 
       case operator
       when :<
-        cards = cards.where(
+        temp_cards[index] = temp_cards[index].where(
           "#{filter} < ?",
           value
         )
       when :>
-        cards = cards.where(
+        temp_cards[index] = temp_cards[index].where(
           "#{filter} > ?",
           value
         )
       when :==
-        cards = cards.where(
+        temp_cards[index] = temp_cards[index].where(
           "#{filter} = ?",
           value
         )
       when :<=
-        cards = cards.where(
+        temp_cards[index] = temp_cards[index].where(
           "#{filter} <= ?",
           value
         )
       when :>=
-        cards = cards.where(
+        temp_cards[index] = temp_cards[index].where(
           "#{filter} >= ?",
           value
         )

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe Card, type: :model do
       @card2 = create(
         :card,
         name: "Draven's Whirling Death",
-        description: "whirling axe"
+        description_raw: "whirling axe"
       )
 
-      @card3 = create(:card, name: "Potato", description: "whirling axe")
+      @card3 = create(:card, name: "Potato", description_raw: "whirling axe")
 
       create_list(:card, 3, name: "Draven")
-      create_list(:card, 3, name: "Draven", description: "axe")
+      create_list(:card, 3, name: "Draven", description_raw: "axe")
     end
 
     it "returns all cards with fuzzy name matches when a basic search is used" do
@@ -28,8 +28,8 @@ RSpec.describe Card, type: :model do
       expect(cards).to_not include(@card3)
     end
 
-    it "returns all cards with fuzzy description matches when the 'description:text' syntax is used" do
-      search_array = { description: ["axe"] }
+    it "returns all cards with fuzzy description matches when the 'description_raw:text' syntax is used" do
+      search_array = { description_raw: ["axe"] }
 
       cards = Card.search(search_array)
 
@@ -40,7 +40,7 @@ RSpec.describe Card, type: :model do
     end
 
     it "returns all cards that satisfy ALL search parameters when multiple search syntaxes are used" do
-      search_array = { name: ["drav"], description: ["axe"] }
+      search_array = { name: ["drav"], description_raw: ["axe"] }
 
       cards = Card.search(search_array)
 
@@ -54,7 +54,7 @@ RSpec.describe Card, type: :model do
       temp_card = create(
         :card,
         name: "Darius's Whirling Death",
-        description: "whirling axe"
+        description_raw: "whirling axe"
       )
 
       search_array = { name: %w[dar whir] }

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Card, type: :model do
     end
 
     it "returns all cards with fuzzy name matches when a basic search is used" do
-      search_array = { name: ["drav"] }
+      search_array = [{ name: ["drav"] }]
 
       cards = Card.search(search_array)
 
@@ -29,7 +29,7 @@ RSpec.describe Card, type: :model do
     end
 
     it "returns all cards with fuzzy description matches when the 'description_raw:text' syntax is used" do
-      search_array = { description_raw: ["axe"] }
+      search_array = [{ description_raw: ["axe"] }]
 
       cards = Card.search(search_array)
 
@@ -40,7 +40,7 @@ RSpec.describe Card, type: :model do
     end
 
     it "returns all cards that satisfy ALL search parameters when multiple search syntaxes are used" do
-      search_array = { name: ["drav"], description_raw: ["axe"] }
+      search_array = [{ name: ["drav"], description_raw: ["axe"] }]
 
       cards = Card.search(search_array)
 
@@ -57,7 +57,7 @@ RSpec.describe Card, type: :model do
         description_raw: "whirling axe"
       )
 
-      search_array = { name: %w[dar whir] }
+      search_array = [{ name: %w[dar whir] }]
 
       cards = Card.search(search_array)
 
@@ -80,7 +80,7 @@ RSpec.describe Card, type: :model do
         keywords: ["Slow Attack"]
       )
 
-      search_array = { rarity: ["champio"] }
+      search_array = [{ rarity: ["champio"] }]
 
       cards = Card.search(search_array)
 
@@ -89,7 +89,7 @@ RSpec.describe Card, type: :model do
       expect(cards).to include(temp_card)
       expect(cards).to_not include(@card1)
 
-      search_array = { artist_name: ["sixmorevodk"] }
+      search_array = [{ artist_name: ["sixmorevodk"] }]
 
       cards = Card.search(search_array)
 
@@ -98,7 +98,7 @@ RSpec.describe Card, type: :model do
       expect(cards).to include(temp_card)
       expect(cards).to_not include(@card1)
 
-      search_array = { set: ["set1"] }
+      search_array = [{ set: ["set1"] }]
 
       cards = Card.search(search_array)
 
@@ -107,7 +107,7 @@ RSpec.describe Card, type: :model do
       expect(cards).to include(temp_card)
       expect(cards).to_not include(@card1)
 
-      search_array = { flavor_text: ["flavor tex"] }
+      search_array = [{ flavor_text: ["flavor tex"] }]
 
       cards = Card.search(search_array)
 
@@ -116,7 +116,7 @@ RSpec.describe Card, type: :model do
       expect(cards).to include(temp_card)
       expect(cards).to_not include(@card1)
 
-      search_array = { card_type: ["unit2"] }
+      search_array = [{ card_type: ["unit2"] }]
 
       cards = Card.search(search_array)
 
@@ -125,7 +125,7 @@ RSpec.describe Card, type: :model do
       expect(cards).to include(temp_card)
       expect(cards).to_not include(@card1)
 
-      search_array = { regions: %w[regionland Other] }
+      search_array = [{ regions: %w[regionland Other] }]
 
       cards = Card.search(search_array)
 
@@ -134,7 +134,7 @@ RSpec.describe Card, type: :model do
       expect(cards).to include(temp_card)
       expect(cards).to_not include(@card1)
 
-      search_array = { formats: %w[nonstandard Other] }
+      search_array = [{ formats: %w[nonstandard Other] }]
 
       cards = Card.search(search_array)
 
@@ -143,7 +143,7 @@ RSpec.describe Card, type: :model do
       expect(cards).to include(temp_card)
       expect(cards).to_not include(@card1)
 
-      search_array = { keywords: ["slow attack", "Other"] }
+      search_array = [{ keywords: ["slow attack", "Other"] }]
 
       cards = Card.search(search_array)
 
@@ -151,7 +151,7 @@ RSpec.describe Card, type: :model do
       expect(cards.count).to eq(1)
       expect(cards).to include(temp_card)
 
-      search_array = {
+      search_array = [{
         rarity: ["champio"],
         artist_name: ["sixmorevodk"],
         set: ["set1"],
@@ -160,7 +160,7 @@ RSpec.describe Card, type: :model do
         regions: %w[regionland Other],
         formats: %w[nonstandard Other],
         keywords: ["slow attack", "Other"]
-      }
+      }]
 
       cards = Card.search(search_array)
 
@@ -175,6 +175,16 @@ RSpec.describe Card, type: :model do
       expect(cards.count).to eq(1)
       expect(cards).to include(temp_card)
       expect(cards).to_not include(@card1)
+    end
+
+    it 'can accept two different sets of filters and combine the results' do
+      search_array = [{name: ["potato"]}, {name: ["draven's whirling death"]}]
+      cards = Card.search(search_array)
+
+      expect(cards).to be_an(ActiveRecord::Relation)
+      expect(cards.count).to eq(2)
+      expect(cards).to include(@card2)
+      expect(cards).to include(@card3)
     end
   end
 

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -177,8 +177,11 @@ RSpec.describe Card, type: :model do
       expect(cards).to_not include(@card1)
     end
 
-    it 'can accept two different sets of filters and combine the results' do
-      search_array = [{name: ["potato"]}, {name: ["draven's whirling death"]}]
+    it "can accept two different sets of filters and combine the results" do
+      search_array = [
+        { name: ["potato"] },
+        { name: ["draven's whirling death"] }
+      ]
       cards = Card.search(search_array)
 
       expect(cards).to be_an(ActiveRecord::Relation)
@@ -201,7 +204,7 @@ RSpec.describe Card, type: :model do
       expect(card).to be_a Card
     end
 
-    it 'can return multiple random cards' do
+    it "can return multiple random cards" do
       cards = Card.random_cards(5)
 
       expect(cards.count).to eq(5)

--- a/spec/requests/api/v1/cards_request_spec.rb
+++ b/spec/requests/api/v1/cards_request_spec.rb
@@ -807,6 +807,9 @@ RSpec.describe Api::V1::CardsController, type: :request do
 
       parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
 
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(1)
+
       get "/api/v1/cards/search?query=" + CGI.escape("health:100")
 
       expect(response).to be_successful

--- a/spec/requests/api/v1/cards_request_spec.rb
+++ b/spec/requests/api/v1/cards_request_spec.rb
@@ -656,6 +656,23 @@ RSpec.describe Api::V1::CardsController, type: :request do
       expect(response.status).to eq(400)
       expect(response.body).to include("invalid is an invalid search query")
     end
+
+    it 'will split a query if there is an OR in the query and parse cards for each set of filters, combining the results' do
+      impossible_card = create(:card, name: "Impossible Card")
+      possible_card = create(:card, name: "Possible Card")
+
+      get "/api/v1/cards/search?query=" + CGI.escape('name:"impossible card" OR name:"possible card"')
+
+      parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      expect(parsed_cards).to be_an(Array)
+      expect(parsed_cards.count).to eq(2)
+      expect(response.body).to include(impossible_card.card_code)
+      expect(response.body).to include(possible_card.card_code)
+    end
   end
 
   describe 'GET /api/v1/cards/random' do

--- a/spec/requests/api/v1/cards_request_spec.rb
+++ b/spec/requests/api/v1/cards_request_spec.rb
@@ -92,13 +92,13 @@ RSpec.describe Api::V1::CardsController, type: :request do
       card2 = create(
         :card,
         name: "Draven's Whirling Death",
-        description: "whirling axe"
+        description_raw: "whirling axe"
       )
-      card3 = create(:card, name: "Potato", description: "whirling axe")
+      card3 = create(:card, name: "Potato", description_raw: "whirling axe")
       create_list(:card, 3, name: "Draven")
-      create_list(:card, 3, name: "Draven", description: "axe")
+      create_list(:card, 3, name: "Draven", description_raw: "axe")
 
-      get "/api/v1/cards/search?query=" + CGI.escape("drav description:axe")
+      get "/api/v1/cards/search?query=" + CGI.escape("drav description_raw:axe")
 
       parsed_cards = JSON.parse(response.body, symbolize_names: true)[:data]
 
@@ -118,7 +118,7 @@ RSpec.describe Api::V1::CardsController, type: :request do
       card2 = create(
         :card,
         name: "Draven's Whirling Death",
-        description: "whirling axe"
+        description_raw: "whirling axe"
       )
 
       get "/api/v1/cards/search?query=" + CGI.escape("drav whir")
@@ -138,7 +138,7 @@ RSpec.describe Api::V1::CardsController, type: :request do
       card1 = create(
         :card,
         name: "Billy",
-        description: "A description",
+        description_raw: "A description",
         regions: %w[Here There],
         formats: ["Format", "Other Format"],
         keywords: ["Keyword", "Other Keyword"],
@@ -155,7 +155,7 @@ RSpec.describe Api::V1::CardsController, type: :request do
       create(
         :card,
         name: "Draven's Whirling Death",
-        description: "whirling axe",
+        description_raw: "whirling axe",
         regions: %w[Demacia Ionia],
         formats: ["Expedition"],
         keywords: ["Quick Attack"],


### PR DESCRIPTION
# Description

Updates search to allow for multiple queries separated by "OR" and returns all cards combined. Also changes description search to query description_raw.

## Context

- Using the word "OR" (case insensitive) allows for multiple queries such as `name:darius or name:draven` and returns all cards that match the first query and all cardss that match the second query
- We were previously querying description which included unique syntax included by Riot and prevented accurate description searches. description_raw removes that syntax. 

Fixes # (issue)

N/A

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Included RSpec tests that demonstrate the usage of "OR"

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules